### PR TITLE
Feature/format function

### DIFF
--- a/JLio.CLient/ParseOptions.cs
+++ b/JLio.CLient/ParseOptions.cs
@@ -33,7 +33,9 @@ namespace JLio.Client
                 .Register<Parse>()
                 .Register<Partial>()
                 .Register<ToString>()
-                .Register<Promote>();
+                .Register<Promote>()
+                .Register<Format>();
+
 
             return new ParseOptions
             {

--- a/JLio.Functions/Format.cs
+++ b/JLio.Functions/Format.cs
@@ -1,4 +1,5 @@
-﻿using JLio.Core;
+﻿using System;
+using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using Newtonsoft.Json.Linq;
@@ -40,8 +41,11 @@ namespace JLio.Functions
 
         private static JLioFunctionResult DoFormat(string formatString, JToken value)
         {
-            // if (value.Type == JTokenType.Date)
-            //   return new JLioFunctionResult(new JValue(value.Value<Datetime>().ToString(formatString)));
+            if (value.Type == JTokenType.Date)
+            {
+                var test = value.Value<DateTime>();
+                return JLioFunctionResult.SuccessFul(new JValue(test.ToString(formatString)));
+            }
 
             return JLioFunctionResult.SuccessFul(value);
         }

--- a/JLio.Functions/Format.cs
+++ b/JLio.Functions/Format.cs
@@ -43,8 +43,8 @@ namespace JLio.Functions
         {
             if (value.Type == JTokenType.Date)
             {
-                var test = value.Value<DateTime>();
-                return JLioFunctionResult.SuccessFul(new JValue(test.ToString(formatString)));
+                var datetimeValue = value.Value<DateTime>();
+                return JLioFunctionResult.SuccessFul(new JValue(datetimeValue.ToString(formatString)));
             }
 
             return JLioFunctionResult.SuccessFul(value);

--- a/JLio.Functions/Format.cs
+++ b/JLio.Functions/Format.cs
@@ -1,0 +1,49 @@
+﻿using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Functions
+{
+    public class Format : FunctionBase
+    {
+        public Format()
+        {
+        }
+
+        public Format(string formatString)
+        {
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(formatString)));
+        }
+
+        public Format(string path, string formatString)
+        {
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""))));
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{formatString}\""))));
+        }
+
+        public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+        {
+            if (Arguments.Count == 0 || Arguments.Count > 2)
+            {
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"failed: {FunctionName} requires 2 arguments (path, newPropertyName)");
+                return JLioFunctionResult.Failed(currentToken);
+            }
+
+            var values = GetArguments(Arguments, currentToken, dataContext, context);
+            if (values.Count == 1)
+                return DoFormat(values[0].ToString().Trim(CoreConstants.StringIndicator), currentToken);
+
+            return DoFormat(values[1].ToString().Trim(CoreConstants.StringIndicator), values[0]);
+        }
+
+        private static JLioFunctionResult DoFormat(string formatString, JToken value)
+        {
+            // if (value.Type == JTokenType.Date)
+            //   return new JLioFunctionResult(new JValue(value.Value<Datetime>().ToString(formatString)));
+
+            return JLioFunctionResult.SuccessFul(value);
+        }
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/FormatTests.cs
+++ b/JLio.UnitTests/FunctionsTests/FormatTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Functions;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.FunctionsTests
+{
+    public class FormatTests
+    {
+        private IExecutionContext executeContext;
+        private ParseOptions parseOptions;
+
+        [SetUp]
+        public void Setup()
+        {
+            parseOptions = ParseOptions.CreateDefault();
+            executeContext = ExecutionContext.CreateDefault();
+        }
+
+        [TestCase("=format($.source,'dd-MM-YYYY')", "{\"source\" : \"2022-01-10T21:15:15.113Z\"}", "{\"new\": 1 }")]
+        public void ScriptTestWithPath(string function, string data, string expectedResult)
+        {
+            var script = $"[{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}]";
+            var result = JLioConvert.Parse(script, parseOptions).Execute(JToken.Parse(data), executeContext);
+
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(executeContext.Logger.LogEntries.TrueForAll(i => i.Level != LogLevel.Error));
+            Assert.IsTrue(JToken.DeepEquals(JToken.Parse(expectedResult), result.Data.SelectToken("$.result")));
+        }
+
+        [TestCase("=format()", "{\"result\" : [1,2]}")]
+        public void WillReturnErrorFalse(string function, string data)
+        {
+            var script = $"[{{\"path\":\"$.result[*]\",\"value\":\"{function}\",\"command\":\"set\"}}]";
+            var result = JLioConvert.Parse(script, parseOptions).Execute(JToken.Parse(data), executeContext);
+
+            Assert.IsTrue(executeContext.Logger.LogEntries.Any(i => i.Level == LogLevel.Error));
+        }
+
+        [Test]
+        public void CanBeUsedInFluentApi()
+        {
+            var script = new JLioScript()
+                    .Set(new Format("$.demo", "dd-MM-yyyy"))
+                    .OnPath("$.id")
+                    .Set(new Format("newer"))
+                    .OnPath("$.demo")
+                ;
+            var result = script.Execute(JToken.Parse("{\"demo\" : 1}"));
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Success);
+        }
+    }
+}


### PR DESCRIPTION
Can format date values to be formatted in a certain way

it uses the C# formatting notation.

can be used in the add, put and Set command. 

has max 2 arguments

path and format

path is optional, when not provided the current value will be used (only working wit a set command