### PR TITLE
Enhance Jlio implementation's flexibility by enabling registration of other functions and commands

### DIFF
--- a/JLio.CLient/ParseOptions.cs
+++ b/JLio.CLient/ParseOptions.cs
@@ -4,42 +4,60 @@ using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Functions;
 using Newtonsoft.Json;
+using System.Threading;
 
 namespace JLio.Client
 {
     public class ParseOptions : IParseOptions
     {
+        public FunctionsProvider FunctionsProvider { get; private set; }
+        public CommandsProvider CommandsProvider { get; private set; }
+
         public JsonConverter JLioFunctionConverter { get; set; }
         public JsonConverter JLioCommandConverter { get; set; }
 
+        public ParseOptions RegisterFunction<F>() where F : IFunction
+        {
+            FunctionsProvider.Register<F>();
+            return this;
+        }
+
+        public ParseOptions RegisterCommand<C>() where C : ICommand
+        {
+            CommandsProvider.Register<C>();
+            return this;
+        }
         public static ParseOptions CreateDefault()
         {
-            var commandProvider = new CommandsProvider();
-            commandProvider
-                .Register<Add>()
-                .Register<Put>()
-                .Register<Set>()
-                .Register<Remove>()
-                .Register<Copy>()
-                .Register<Move>()
-                .Register<Compare>()
-                .Register<Merge>();
+            var commandsProvider = new CommandsProvider();
+            commandsProvider
+               .Register<Add>()
+               .Register<Put>()
+               .Register<Set>()
+               .Register<Remove>()
+               .Register<Copy>()
+               .Register<Move>()
+               .Register<Compare>()
+               .Register<Merge>();
 
             var functionsProvider = new FunctionsProvider();
             functionsProvider
-                .Register<Datetime>()
-                .Register<NewGuid>()
-                .Register<Concat>()
-                .Register<Parse>()
-                .Register<Partial>()
-                .Register<ToString>()
-                .Register<Promote>()
-                .Register<Format>();
+               .Register<Datetime>()
+               .Register<NewGuid>()
+               .Register<Concat>()
+               .Register<Parse>()
+               .Register<Partial>()
+               .Register<ToString>()
+               .Register<Promote>()
+               .Register<Format>();
+
 
 
             return new ParseOptions
             {
-                JLioCommandConverter = new CommandConverter(commandProvider),
+                FunctionsProvider = functionsProvider,
+                CommandsProvider = commandsProvider,
+                JLioCommandConverter = new CommandConverter(commandsProvider),
                 JLioFunctionConverter = new FunctionConverter(functionsProvider)
             };
         }

--- a/JLio.UnitTests/FunctionsTests/ParseTests.cs
+++ b/JLio.UnitTests/FunctionsTests/ParseTests.cs
@@ -3,6 +3,7 @@ using JLio.Client;
 using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
+using JLio.Extensions.JSchema;
 using JLio.Functions;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -18,7 +19,8 @@ namespace JLio.UnitTests.FunctionsTests
         [SetUp]
         public void Setup()
         {
-            parseOptions = ParseOptions.CreateDefault();
+            parseOptions = ParseOptions.CreateDefault()
+                .RegisterFunction<FilterBySchema>();
             executeContext = ExecutionContext.CreateDefault();
         }
 


### PR DESCRIPTION
…f additional functions and commands alongside default options.

With this update, it's now possible to register extra extensions or packages seamlessly while still using default parse options. The change was achieved by creating a ParseOptions instance using the CreateDefault() method and then registering a new function like FilterBySchema using the RegisterFunction() method.

This improvement increases the overall usability and extensibility of the Jlio implementation, enabling developers to easily build upon existing functionality without losing the benefits of default options.