### PR TITLE
fix for the internal execution of functions

### DIFF
--- a/JLio.CLient/ParseOptions.cs
+++ b/JLio.CLient/ParseOptions.cs
@@ -49,7 +49,8 @@ namespace JLio.Client
                .Register<Partial>()
                .Register<ToString>()
                .Register<Promote>()
-               .Register<Format>();
+               .Register<Format>()
+               .Register<Fetch>();
 
 
 

--- a/JLio.CLient/ParseOptions.cs
+++ b/JLio.CLient/ParseOptions.cs
@@ -51,7 +51,7 @@ public class ParseOptions : IParseOptions
            .Register<ToString>()
            .Register<Promote>()
            .Register<Format>()
-           .Register<Fetch>(); ;
+           .Register<Fetch>(); 
 
 
 

--- a/JLio.Commands/Add.cs
+++ b/JLio.Commands/Add.cs
@@ -16,7 +16,7 @@ public class Add : PropertyChangeCommand
     public Add(string path, JToken value)
     {
         Path = path;
-        Value = new FunctionSupportedValue(new FixedValue(value));
+        Value = new FunctionSupportedValue(new FixedValue(value, null));
     }
 
     public Add(string path, IFunctionSupportedValue value)

--- a/JLio.Commands/Builders/AddBuilders.cs
+++ b/JLio.Commands/Builders/AddBuilders.cs
@@ -9,7 +9,7 @@ public static class AddBuilders
 {
     public static JLioScript OnPath(this AddValueContainer source, string path)
     {
-        source.Script.AddLine(new Add(path, new FunctionSupportedValue(new FixedValue(source.Value))));
+        source.Script.AddLine(new Add(path, new FunctionSupportedValue(new FixedValue(source.Value, null))));
         return source.Script;
     }
 

--- a/JLio.Commands/Builders/PutBuilders.cs
+++ b/JLio.Commands/Builders/PutBuilders.cs
@@ -9,7 +9,7 @@ public static class PutBuilders
 {
     public static JLioScript OnPath(this PutValueContainer source, string path)
     {
-        source.Script.AddLine(new Put(path, new FunctionSupportedValue(new FixedValue(source.Value))));
+        source.Script.AddLine(new Put(path, new FunctionSupportedValue(new FixedValue(source.Value,null))));
         return source.Script;
     }
 

--- a/JLio.Commands/Builders/SetBuilders.cs
+++ b/JLio.Commands/Builders/SetBuilders.cs
@@ -9,7 +9,7 @@ public static class SetBuilders
 {
     public static JLioScript OnPath(this SetValueContainer source, string path)
     {
-        source.Script.AddLine(new Set(path, new FunctionSupportedValue(new FixedValue(source.Value))));
+        source.Script.AddLine(new Set(path, new FunctionSupportedValue(new FixedValue(source.Value, null))));
         return source.Script;
     }
 

--- a/JLio.Commands/Put.cs
+++ b/JLio.Commands/Put.cs
@@ -16,7 +16,7 @@ public class Put : PropertyChangeCommand
     public Put(string path, JToken value)
     {
         Path = path;
-        Value = new FunctionSupportedValue(new FixedValue(value));
+        Value = new FunctionSupportedValue(new FixedValue(value, null));
     }
 
     public Put(string path, IFunctionSupportedValue value)

--- a/JLio.Commands/Set.cs
+++ b/JLio.Commands/Set.cs
@@ -20,7 +20,7 @@ public class Set : PropertyChangeCommand
     public Set(string path, JToken value)
     {
         Path = path;
-        Value = new FunctionSupportedValue(new FixedValue(value));
+        Value = new FunctionSupportedValue(new FixedValue(value, null));
     }
 
     public Set(string path, IFunctionSupportedValue value)

--- a/JLio.Core/FixedValue.cs
+++ b/JLio.Core/FixedValue.cs
@@ -8,81 +8,83 @@ namespace JLio.Core;
 
 public class FixedValue : IFunction
 {
-    public FixedValue(JToken value)
+    public FixedValue(JToken value, FunctionConverter functionConverter)
     {
         Value = value;
+        this.FunctionConverter = functionConverter;
     }
 
     public JToken Value { get; }
 
     public string FunctionName => "FixedValue";
 
-       public FunctionConverter FunctionConverter { get;  set; }
+    public FunctionConverter FunctionConverter { get; set; }
 
-        public IFunction SetArguments(Arguments newArguments)
+    public IFunction SetArguments(Arguments newArguments)
+    {
+        return this;
+    }
+
+    public JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        if (Value.Type == JTokenType.String) return HandleString(currentToken, dataContext, context);
+        if (FunctionConverter != null && (Value.Type == JTokenType.Object || Value.Type == JTokenType.Array)) return ProcessToken(Value, currentToken, dataContext, context);
+        return new JLioFunctionResult(true, Value);
+    }
+
+    private JLioFunctionResult ProcessToken(JToken token, JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var clone = token.DeepClone();
+        if (token.Type == JTokenType.Object) ProcessObject((JObject)clone, currentToken, dataContext, context);
+        if (token.Type == JTokenType.Array) ProcessArray((JArray)clone, currentToken, dataContext, context);
+        return new JLioFunctionResult(true, clone);
+    }
+
+    private void ProcessObject(JObject obj, JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        foreach (var prop in obj.Properties().ToList())
         {
-            return this;
+            prop.Value = ProcessValue(prop.Value, currentToken, dataContext, context);
         }
+    }
 
-        public JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    private void ProcessArray(JArray array, JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        for (int i = 0; i < array.Count; i++)
+            array[i] = ProcessValue(array[i], currentToken, dataContext, context);
+    }
+
+    private JToken ProcessValue(JToken value, JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        if (IsFunction(value)) return ExecuteFunction(value.ToString(), currentToken, dataContext, context);
+        if (value.Type == JTokenType.Object || value.Type == JTokenType.Array) { ProcessToken(value, currentToken, dataContext, context); }
+        ;
+        return value;
+    }
+
+    private bool IsFunction(JToken token)
+    {
+        return token.Type == JTokenType.String && token.ToString().StartsWith("=");
+    }
+
+    private JToken ExecuteFunction(string expression, JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        if (FunctionConverter == null)
         {
-            if (Value.Type == JTokenType.String) return HandleString(currentToken, dataContext, context);
-            if (FunctionConverter != null &&   (Value.Type == JTokenType.Object || Value.Type == JTokenType.Array)) return ProcessToken(Value, currentToken, dataContext, context);
-            return new JLioFunctionResult(true, Value);
+            context.LogError(CoreConstants.FunctionExecution, "FunctionsConverter is not set for FixedValue execution.");
+            return JValue.CreateString(expression); // or throw an exception
         }
+        var function = FunctionConverter.ParseString(expression);
+        var result = function.GetValue(currentToken, dataContext, context); // Execute the function with the current context
+        if (!result.Success)
+            return JValue.CreateString(expression);
+        return result.Data.FirstOrDefault(); // Return the result of the function execution   
 
-        private JLioFunctionResult ProcessToken(JToken token, JToken currentToken, JToken dataContext, IExecutionContext context)
-        {
-            var clone = token.DeepClone();
-            if (token.Type == JTokenType.Object) ProcessObject((JObject)clone, currentToken, dataContext, context);
-            if (token.Type == JTokenType.Array) ProcessArray((JArray)clone, currentToken, dataContext, context);
-            return new JLioFunctionResult(true, clone);
-        }
+    }
 
-        private void ProcessObject(JObject obj, JToken currentToken, JToken dataContext, IExecutionContext context)
-        {
-            foreach (var prop in obj.Properties().ToList())
-            {
-                prop.Value = ProcessValue(prop.Value, currentToken, dataContext, context);
-            }
-        }
-
-        private void ProcessArray(JArray array, JToken currentToken, JToken dataContext, IExecutionContext context)
-        {
-            for (int i = 0; i < array.Count; i++)
-                array[i] = ProcessValue(array[i], currentToken, dataContext, context);
-        }
-
-        private JToken ProcessValue(JToken value, JToken currentToken, JToken dataContext, IExecutionContext context)
-        {
-            if (IsFunction(value)) return ExecuteFunction(value.ToString(), currentToken, dataContext, context);
-            if (value.Type == JTokenType.Object || value.Type == JTokenType.Array) { ProcessToken(value, currentToken, dataContext, context); };
-            return value;
-        }
-
-        private bool IsFunction(JToken token)
-        {
-            return token.Type == JTokenType.String && token.ToString().StartsWith("=");
-        }
-
-        private JToken ExecuteFunction(string expression, JToken currentToken, JToken dataContext, IExecutionContext context)
-        {
-            if(FunctionConverter == null)
-            {
-                context.LogError(CoreConstants.FunctionExecution, "FunctionsConverter is not set for FixedValue execution.");
-                return JValue.CreateString(expression); // or throw an exception
-            }
-           var function = FunctionConverter.ParseString(expression);
-           var result = function.GetValue(currentToken, dataContext, context); // Execute the function with the current context
-              if (!result.Success)
-                return JValue.CreateString(expression);
-            return result.Data.FirstOrDefault(); // Return the result of the function execution   
-
-        }
-
-        //traverse if it is a object or array 
-        // properties that are a string and start with =
-        // try parse to fucntion and exectute function
+    //traverse if it is a object or array 
+    // properties that are a string and start with =
+    // try parse to fucntion and exectute function
 
 
     public string ToScript()

--- a/JLio.Core/FixedValue.cs
+++ b/JLio.Core/FixedValue.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using JLio.Core.Contracts;
+﻿using JLio.Core.Contracts;
 using JLio.Core.Models;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
 
 namespace JLio.Core
 {
@@ -16,6 +17,8 @@ namespace JLio.Core
 
         public string FunctionName => "FixedValue";
 
+       public FunctionConverter FunctionConverter { get;  set; }
+
         public IFunction SetArguments(Arguments newArguments)
         {
             return this;
@@ -24,8 +27,63 @@ namespace JLio.Core
         public JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
         {
             if (Value.Type == JTokenType.String) return HandleString(currentToken, dataContext, context);
+            if (FunctionConverter != null &&   (Value.Type == JTokenType.Object || Value.Type == JTokenType.Array)) return ProcessToken(Value, currentToken, dataContext, context);
             return new JLioFunctionResult(true, Value);
         }
+
+        private JLioFunctionResult ProcessToken(JToken token, JToken currentToken, JToken dataContext, IExecutionContext context)
+        {
+            var clone = token.DeepClone();
+            if (token.Type == JTokenType.Object) ProcessObject((JObject)clone, currentToken, dataContext, context);
+            if (token.Type == JTokenType.Array) ProcessArray((JArray)clone, currentToken, dataContext, context);
+            return new JLioFunctionResult(true, clone);
+        }
+
+        private void ProcessObject(JObject obj, JToken currentToken, JToken dataContext, IExecutionContext context)
+        {
+            foreach (var prop in obj.Properties().ToList())
+            {
+                prop.Value = ProcessValue(prop.Value, currentToken, dataContext, context);
+            }
+        }
+
+        private void ProcessArray(JArray array, JToken currentToken, JToken dataContext, IExecutionContext context)
+        {
+            for (int i = 0; i < array.Count; i++)
+                array[i] = ProcessValue(array[i], currentToken, dataContext, context);
+        }
+
+        private JToken ProcessValue(JToken value, JToken currentToken, JToken dataContext, IExecutionContext context)
+        {
+            if (IsFunction(value)) return ExecuteFunction(value.ToString(), currentToken, dataContext, context);
+            if (value.Type == JTokenType.Object || value.Type == JTokenType.Array) { ProcessToken(value, currentToken, dataContext, context); };
+            return value;
+        }
+
+        private bool IsFunction(JToken token)
+        {
+            return token.Type == JTokenType.String && token.ToString().StartsWith("=");
+        }
+
+        private JToken ExecuteFunction(string expression, JToken currentToken, JToken dataContext, IExecutionContext context)
+        {
+            if(FunctionConverter == null)
+            {
+                context.LogError(CoreConstants.FunctionExecution, "FunctionsConverter is not set for FixedValue execution.");
+                return JValue.CreateString(expression); // or throw an exception
+            }
+           var function = FunctionConverter.ParseString(expression);
+           var result = function.GetValue(currentToken, dataContext, context); // Execute the function with the current context
+              if (!result.Success)
+                return JValue.CreateString(expression);
+            return result.Data.FirstOrDefault(); // Return the result of the function execution   
+
+        }
+
+        //traverse if it is a object or array 
+        // properties that are a string and start with =
+        // try parse to fucntion and exectute function
+
 
         public string ToScript()
         {

--- a/JLio.Core/FunctionConverter.cs
+++ b/JLio.Core/FunctionConverter.cs
@@ -46,11 +46,11 @@ namespace JLio.Core
             return new FunctionSupportedValue(new FixedValue(value));
         }
 
-        private IFunctionSupportedValue ParseString(string text)
+        public IFunctionSupportedValue ParseString(string text)
         {
             if (string.IsNullOrEmpty(text)) return new FunctionSupportedValue(new FixedValue(JValue.CreateNull()));
             if (!text.StartsWith(CoreConstants.FunctionStartCharacters))
-                return new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{text}\"")));
+                return new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{text}\"")) { FunctionConverter = this });
             var (function, arguments) = GetFunctionAndArguments(text);
 
             return new FunctionSupportedValue(function.SetArguments(arguments));

--- a/JLio.Core/FunctionConverter.cs
+++ b/JLio.Core/FunctionConverter.cs
@@ -43,14 +43,14 @@ public class FunctionConverter : JsonConverter
         var value = JToken.Load(reader);
         if (value.Type == JTokenType.String) return ParseString(value.ToString());
 
-        return new FunctionSupportedValue(new FixedValue(value));
+        return new FunctionSupportedValue(new FixedValue(value, this));
     }
 
         public IFunctionSupportedValue ParseString(string text)
         {
-            if (string.IsNullOrEmpty(text)) return new FunctionSupportedValue(new FixedValue(JValue.CreateNull()));
+            if (string.IsNullOrEmpty(text)) return new FunctionSupportedValue(new FixedValue(JValue.CreateNull(), this));
             if (!text.StartsWith(CoreConstants.FunctionStartCharacters))
-                return new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{text}\"")) { FunctionConverter = this });
+                return new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{text}\""), this));
             var (function, arguments) = GetFunctionAndArguments(text);
 
         return new FunctionSupportedValue(function.SetArguments(arguments));
@@ -70,7 +70,7 @@ public class FunctionConverter : JsonConverter
         if (mainSplit.Count > 1 && function != null)
             return DiscoverFunctionsUsedInArguments(function, mainSplit[1].Text);
 
-        return (new FixedValue(new JValue(text)), new Arguments());
+        return (new FixedValue(new JValue(text), this), new Arguments());
     }
 
     private (IFunction function, Arguments arguments) DiscoverFunctionsUsedInArguments(IFunction function,

--- a/JLio.Extensions.JSchema/FilterBySchema.cs
+++ b/JLio.Extensions.JSchema/FilterBySchema.cs
@@ -21,12 +21,12 @@ public class FilterBySchema : FunctionBase
 
     public FilterBySchema(NewtonsoftJSchema schema)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(schema.ToString())));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(schema.ToString(),null)));
     }
 
     public FilterBySchema(string path)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(path,null)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Concat.cs
+++ b/JLio.Functions/Concat.cs
@@ -16,7 +16,7 @@ public class Concat : FunctionBase
     public Concat(params string[] arguments)
     {
         arguments.ToList().ForEach(a =>
-            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a, null))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Datetime.cs
+++ b/JLio.Functions/Datetime.cs
@@ -31,7 +31,7 @@ public class Datetime : FunctionBase
     public Datetime(params string[] arguments)
     {
         arguments.ToList().ForEach(a =>
-            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a, null))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Fetch.cs
+++ b/JLio.Functions/Fetch.cs
@@ -15,7 +15,7 @@ namespace JLio.Functions
 
         public Fetch(string path)
         {
-                Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
+                Arguments.Add(new FunctionSupportedValue(new FixedValue(path, null)));
         }
 
         public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Fetch.cs
+++ b/JLio.Functions/Fetch.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Functions
+{
+    public class Fetch : FunctionBase
+    {
+        public Fetch()
+        {
+        }
+
+        public Fetch(string path)
+        {
+                Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
+        }
+
+        public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+        {
+            
+
+            var argumentValue = GetArguments(Arguments, currentToken, dataContext, context).FirstOrDefault();
+                if(argumentValue == null)
+            {
+                return  new JLioFunctionResult(false, JValue.CreateNull());
+            }
+           
+            return new JLioFunctionResult(true, argumentValue);
+        }
+    }
+}

--- a/JLio.Functions/Format.cs
+++ b/JLio.Functions/Format.cs
@@ -15,13 +15,13 @@ public class Format : FunctionBase
 
     public Format(string formatString)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(formatString)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(formatString,null)));
     }
 
     public Format(string path, string formatString)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""))));
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{formatString}\""))));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""),null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{formatString}\""),null)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Parse.cs
+++ b/JLio.Functions/Parse.cs
@@ -16,7 +16,7 @@ public class Parse : FunctionBase
 
     public Parse(string path)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(path, null)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Partial.cs
+++ b/JLio.Functions/Partial.cs
@@ -17,7 +17,7 @@ public class Partial : FunctionBase
     public Partial(params string[] arguments)
     {
         arguments.ToList().ForEach(a =>
-            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a, null))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Promote.cs
+++ b/JLio.Functions/Promote.cs
@@ -13,13 +13,13 @@ public class Promote : FunctionBase
 
     public Promote(string newPropertyName)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(newPropertyName)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(newPropertyName, null)));
     }
 
     public Promote(string path, string newPropertyName)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""))));
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{newPropertyName}\""))));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""),null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{newPropertyName}\""),null)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/ToString.cs
+++ b/JLio.Functions/ToString.cs
@@ -15,7 +15,7 @@ public class ToString : FunctionBase
 
     public ToString(string path)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(path, null)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.UnitTests/CommandsTests/AddTests.cs
+++ b/JLio.UnitTests/CommandsTests/AddTests.cs
@@ -100,7 +100,8 @@ namespace JLio.UnitTests.CommandsTests
         }
 
         [TestCase("$.newProperty", "{\"demo\" : \"=newGuid()\"}")]
-        [TestCase("$.newProperty", "{\"demo\" : \"=concat($.myString, '-demo')\"}")]
+        [TestCase("$.newProperty", "{\"demo\" : \"=concat($.myString, '-demo-', newGuid())\", \"demo2\" : \"=concat($.myString, '-demo2-', newGuid())\"}")]
+        [TestCase("$.newProperty", "{\"newprop\" : { \"newSubProp\" : 56},   \"demo\" : \"=fetch($.myObject.myArray)\", \"demo2\" : \"=concat($.myString, '-demo2-', newGuid())\", \"demo2\" : \"=fetch($.myArray[1])\"}")]
         public void CanAddCorrectValuesAsFunctions(string path, string value)
         {
             var tokenToAdd = JToken.Parse(value);

--- a/JLio.UnitTests/CommandsTests/AddTests.cs
+++ b/JLio.UnitTests/CommandsTests/AddTests.cs
@@ -75,7 +75,7 @@ public class AddTests
     public void CanAddCorrectValuesWithEmptyConstructor(string path, string value)
     {
         var command = new Add
-            {Path = path, Value = new FunctionSupportedValue(new FixedValue(new JValue(value)))};
+        { Path = path, Value = new FunctionSupportedValue(new FixedValue(new JValue(value))) };
 
         var result = command.Execute(data, executeOptions);
 
@@ -99,30 +99,24 @@ public class AddTests
         Assert.IsTrue(JToken.DeepEquals(data.SelectToken(path), tokenToAdd));
     }
 
-        [TestCase("$.newProperty", "{\"demo\" : \"=newGuid()\"}")]
-        [TestCase("$.newProperty", "{\"demo\" : \"=concat($.myString, '-demo-', newGuid())\", \"demo2\" : \"=concat($.myString, '-demo2-', newGuid())\"}")]
-        [TestCase("$.newProperty", "{\"newprop\" : { \"newSubProp\" : 56},   \"demo\" : \"=fetch($.myObject.myArray)\", \"demo2\" : \"=concat($.myString, '-demo2-', newGuid())\", \"demo2\" : \"=fetch($.myArray[1])\"}")]
-        public void CanAddCorrectValuesAsFunctions(string path, string value)
-        {
-            var tokenToAdd = JToken.Parse(value);
-            FunctionConverter functionsConverter = new FunctionConverter( ParseOptions.CreateDefault().FunctionsProvider);
-            var valueToAdd = new FunctionSupportedValue(new FixedValue(tokenToAdd) { FunctionConverter = functionsConverter });
-            var result = new Add(path, valueToAdd).Execute(data, executeOptions);
+    [TestCase("$.newProperty", "{\"demo\" : \"=newGuid()\"}")]
+    [TestCase("$.newProperty", "{\"demo\" : \"=concat($.myString, '-demo-', newGuid())\", \"demo2\" : \"=concat($.myString, '-demo2-', newGuid())\"}")]
+    [TestCase("$.newProperty", "{\"newprop\" : { \"newSubProp\" : 56},   \"demo\" : \"=fetch($.myObject.myArray)\", \"demo2\" : \"=concat($.myString, '-demo2-', newGuid())\", \"demo2\" : \"=fetch($.myArray[1])\"}")]
+    public void CanAddCorrectValuesAsFunctions(string path, string value)
+    {
+        var tokenToAdd = JToken.Parse(value);
+        FunctionConverter functionsConverter = new FunctionConverter(ParseOptions.CreateDefault().FunctionsProvider);
+        var valueToAdd = new FunctionSupportedValue(new FixedValue(tokenToAdd) { FunctionConverter = functionsConverter });
+        var result = new Add(path, valueToAdd).Execute(data, executeOptions);
 
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result.Success);
-            Assert.IsTrue(data.SelectTokens(path).All(i => i.Type != JTokenType.Null));
-            Assert.IsTrue(data.SelectTokens(path).Any());
-            // it should not be the same as the tokenToAdd, because the function is executed
-            Assert.IsFalse(JToken.DeepEquals(data.SelectToken(path), tokenToAdd));
-        }
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(data.SelectTokens(path).All(i => i.Type != JTokenType.Null));
+        Assert.IsTrue(data.SelectTokens(path).Any());
+        // it should not be the same as the tokenToAdd, because the function is executed
+        Assert.IsFalse(JToken.DeepEquals(data.SelectToken(path), tokenToAdd));
+    }
 
-        [TestCase("", "newData", "Path property for add command is missing")]
-        [TestCase("", null, "Path property for add command is missing")]
-        public void CanExecuteWithArgumentsNotProvided(string path, string value, string message)
-        {
-            var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value)));
-            var result = new Add(path, valueToAdd).Execute(data, executeOptions);
     [TestCase("", "newData", "Path property for add command is missing")]
     [TestCase("", null, "Path property for add command is missing")]
     public void CanExecuteWithArgumentsNotProvided(string path, string value, string message)

--- a/JLio.UnitTests/CommandsTests/PutTests.cs
+++ b/JLio.UnitTests/CommandsTests/PutTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using JLio.Client;
 using JLio.Commands;
 using JLio.Commands.Builders;
 using JLio.Core;
@@ -13,12 +14,13 @@ namespace JLio.UnitTests.CommandsTests;
 public class PutTests
 {
     private JToken data;
-
+    private FunctionConverter functionConverter;
     private IExecutionContext executeOptions;
 
     [SetUp]
     public void Setup()
     {
+        functionConverter = new FunctionConverter(ParseOptions.CreateDefault().FunctionsProvider);
         executeOptions = ExecutionContext.CreateDefault();
         data = JToken.Parse(
             "{\r\n  \"myString\": \"demo2\",\r\n  \"myNumber\": 2.2,\r\n  \"myInteger\": 20,\r\n  \"myObject\": {\r\n    \"myObject\": {\"myArray\": [\r\n      2,\r\n      20,\r\n      200,\r\n      2000\r\n    ]},\r\n    \"myArray\": [\r\n      2,\r\n      20,\r\n      200,\r\n      2000\r\n    ]\r\n  },\r\n  \"myArray\": [\r\n    2,\r\n    20,\r\n    200,\r\n    2000\r\n  ],\r\n  \"myBoolean\": true,\r\n  \"myNull\": null\r\n}");
@@ -35,7 +37,7 @@ public class PutTests
         "newData")] // this is not working yet  need to consult newtonsoft
     public void CanPutValues(string path, string value)
     {
-        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value)));
+        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter));
         var result = new Put(path, valueToAdd).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);
@@ -50,7 +52,7 @@ public class PutTests
     [TestCase("$.newProperty", "newData")]
     public void CanPutCorrectValues(string path, string value)
     {
-        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value)));
+        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter));
         var result = new Put(path, valueToAdd).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);
@@ -74,7 +76,7 @@ public class PutTests
     public void CanPutCorrectValuesWithEmptyConstructor(string path, string value)
     {
         var command = new Put
-            {Path = path, Value = new FunctionSupportedValue(new FixedValue(new JValue(value)))};
+            {Path = path, Value = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter))};
 
         var result = command.Execute(data, executeOptions);
 
@@ -88,7 +90,7 @@ public class PutTests
     public void CanPutCorrectValuesAsTokens(string path, string value)
     {
         var tokenToAdd = JToken.Parse(value);
-        var valueToAdd = new FunctionSupportedValue(new FixedValue(tokenToAdd));
+        var valueToAdd = new FunctionSupportedValue(new FixedValue(tokenToAdd, functionConverter ));
         var result = new Put(path, valueToAdd).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);
@@ -102,7 +104,7 @@ public class PutTests
     [TestCase("", null, "Path property for put command is missing")]
     public void CanExecuteWithArgumentsNotProvided(string path, string value, string message)
     {
-        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value)));
+        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter));
         var result = new Put(path, valueToAdd).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);

--- a/JLio.UnitTests/CommandsTests/SetTests.cs
+++ b/JLio.UnitTests/CommandsTests/SetTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+﻿using JLio.Client;
 using JLio.Commands;
 using JLio.Commands.Builders;
 using JLio.Core;
@@ -7,17 +7,20 @@ using JLio.Core.Models;
 using JLio.Functions;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using System.Linq;
 
 namespace JLio.UnitTests.CommandsTests;
 
 public class SetTests
 {
     private JToken data;
+    private FunctionConverter functionConverter;
     private IExecutionContext executeOptions;
 
     [SetUp]
     public void Setup()
     {
+        functionConverter = new FunctionConverter(ParseOptions.CreateDefault().FunctionsProvider);
         executeOptions = ExecutionContext.CreateDefault();
         data = JToken.Parse(
             "{\r\n  \"myString\": \"demo2\",\r\n  \"myNumber\": 2.2,\r\n  \"myInteger\": 20,\r\n  \"myObject\": {\r\n    \"myObject\": {\"myArray\": [\r\n      2,\r\n      20,\r\n      200,\r\n      2000\r\n    ]},\r\n    \"myArray\": [\r\n      2,\r\n      20,\r\n      200,\r\n      2000\r\n    ]\r\n  },\r\n  \"myArray\": [\r\n    2,\r\n    20,\r\n    200,\r\n    2000\r\n  ],\r\n  \"myBoolean\": true,\r\n  \"myNull\": null\r\n}");
@@ -31,7 +34,7 @@ public class SetTests
     [TestCase("$.myString", "newData")]
     public void CanSetValues(string path, string value)
     {
-        var valueToSet = new FunctionSupportedValue(new FixedValue(new JValue(value)));
+        var valueToSet = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter));
         var result = new Set(path, valueToSet).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);
@@ -45,7 +48,7 @@ public class SetTests
     [TestCase("$.myString", "newData")]
     public void CanSetCorrectValues(string path, string value)
     {
-        var valueToSet = new FunctionSupportedValue(new FixedValue(new JValue(value)));
+        var valueToSet = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter));
         var result = new Set(path, valueToSet).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);
@@ -62,7 +65,7 @@ public class SetTests
     [TestCase("$.myString", "")]
     public void CanSetCorrectValuesEmptyString(string path, string value)
     {
-        var valueToSet = new FunctionSupportedValue(new FixedValue(new JValue(value)));
+        var valueToSet = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter));
         var result = new Set(path, valueToSet).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);
@@ -76,7 +79,7 @@ public class SetTests
     [TestCase("", null, "Path property for set command is missing")]
     public void CanExecuteWithArgumentsNotProvided(string path, string value, string message)
     {
-        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value)));
+        var valueToAdd = new FunctionSupportedValue(new FixedValue(new JValue(value), functionConverter));
         var result = new Set(path, valueToAdd).Execute(data, executeOptions);
 
         Assert.IsNotNull(result);

--- a/JLio.UnitTests/ScriptTextHandling/TextHandling.cs
+++ b/JLio.UnitTests/ScriptTextHandling/TextHandling.cs
@@ -56,7 +56,7 @@ public class TextHandling
     }
 
     [TestCase("", "{\"myObject\":{\"initialProperty\":\"initial value\"}}")]
-    [TestCase("[{\"path\":\"$.myObject.newProperty\",\"value\":\"new value\",\"command\":\"add\"}]",
+    [TestCase("[{\"path\":\"$.myObject.newProperty\",\"value\":\"=newGuid()\",\"command\":\"add\"}]",
         "{\"myObject\":{\"initialProperty\":\"initial value\"}}")]
     public void CanParseAndExecute(string scriptText, string data)
     {


### PR DESCRIPTION
#### PR Classification
Code enhancement to improve function handling and testing.

#### PR Summary
This pull request updates the handling of function converters across multiple classes to enhance functionality and testing. Key changes include:
- `release.yml`: Updated NuGet API key environment variable from `${NUGET_API_KEY_FE}` to `${NUGET_TOKEN}`.
- `FixedValue.cs`: Modified to accept a `FunctionConverter` in its constructor and improved function execution methods.
- `Add.cs`, `Put.cs`, `Set.cs`: Constructors updated to include a `null` parameter for `FixedValue` instantiation.
- `FunctionConverter.cs`: Updated to pass the `FunctionConverter` instance when creating `FunctionSupportedValue` objects.
- Test classes (`AddTests`, `PutTests`, `SetTests`): Updated to include a `FunctionConverter` instance in their setup for better testing coverage.
