### PR TITLE
Ensure FixedValue always has a FunctionConverter

### DIFF
--- a/JLio.CLient/ParseOptions.cs
+++ b/JLio.CLient/ParseOptions.cs
@@ -4,7 +4,6 @@ using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Functions;
 using Newtonsoft.Json;
-using System.Threading;
 
 namespace JLio.Client;
 
@@ -51,16 +50,20 @@ public class ParseOptions : IParseOptions
            .Register<ToString>()
            .Register<Promote>()
            .Register<Format>()
-           .Register<Fetch>(); 
+           .Register<Fetch>();
 
 
 
-        return new ParseOptions
+        var options = new ParseOptions
         {
             FunctionsProvider = functionsProvider,
             CommandsProvider = commandsProvider,
             JLioCommandConverter = new CommandConverter(commandsProvider),
             JLioFunctionConverter = new FunctionConverter(functionsProvider)
         };
+
+        FixedValue.DefaultFunctionConverter = (FunctionConverter)options.JLioFunctionConverter;
+
+        return options;
     }
 }

--- a/JLio.Commands/Add.cs
+++ b/JLio.Commands/Add.cs
@@ -16,7 +16,7 @@ public class Add : PropertyChangeCommand
     public Add(string path, JToken value)
     {
         Path = path;
-        Value = new FunctionSupportedValue(new FixedValue(value, null));
+        Value = new FunctionSupportedValue(new FixedValue(value));
     }
 
     public Add(string path, IFunctionSupportedValue value)

--- a/JLio.Commands/Builders/AddBuilders.cs
+++ b/JLio.Commands/Builders/AddBuilders.cs
@@ -9,7 +9,7 @@ public static class AddBuilders
 {
     public static JLioScript OnPath(this AddValueContainer source, string path)
     {
-        source.Script.AddLine(new Add(path, new FunctionSupportedValue(new FixedValue(source.Value, null))));
+        source.Script.AddLine(new Add(path, new FunctionSupportedValue(new FixedValue(source.Value))));
         return source.Script;
     }
 

--- a/JLio.Commands/Builders/PutBuilders.cs
+++ b/JLio.Commands/Builders/PutBuilders.cs
@@ -9,7 +9,7 @@ public static class PutBuilders
 {
     public static JLioScript OnPath(this PutValueContainer source, string path)
     {
-        source.Script.AddLine(new Put(path, new FunctionSupportedValue(new FixedValue(source.Value,null))));
+        source.Script.AddLine(new Put(path, new FunctionSupportedValue(new FixedValue(source.Value))));
         return source.Script;
     }
 

--- a/JLio.Commands/Builders/SetBuilders.cs
+++ b/JLio.Commands/Builders/SetBuilders.cs
@@ -9,7 +9,7 @@ public static class SetBuilders
 {
     public static JLioScript OnPath(this SetValueContainer source, string path)
     {
-        source.Script.AddLine(new Set(path, new FunctionSupportedValue(new FixedValue(source.Value, null))));
+        source.Script.AddLine(new Set(path, new FunctionSupportedValue(new FixedValue(source.Value))));
         return source.Script;
     }
 

--- a/JLio.Commands/Put.cs
+++ b/JLio.Commands/Put.cs
@@ -16,7 +16,7 @@ public class Put : PropertyChangeCommand
     public Put(string path, JToken value)
     {
         Path = path;
-        Value = new FunctionSupportedValue(new FixedValue(value, null));
+        Value = new FunctionSupportedValue(new FixedValue(value));
     }
 
     public Put(string path, IFunctionSupportedValue value)

--- a/JLio.Commands/Set.cs
+++ b/JLio.Commands/Set.cs
@@ -20,7 +20,7 @@ public class Set : PropertyChangeCommand
     public Set(string path, JToken value)
     {
         Path = path;
-        Value = new FunctionSupportedValue(new FixedValue(value, null));
+        Value = new FunctionSupportedValue(new FixedValue(value));
     }
 
     public Set(string path, IFunctionSupportedValue value)

--- a/JLio.Core/FixedValue.cs
+++ b/JLio.Core/FixedValue.cs
@@ -8,10 +8,13 @@ namespace JLio.Core;
 
 public class FixedValue : IFunction
 {
-    public FixedValue(JToken value, FunctionConverter functionConverter)
+    public static FunctionConverter DefaultFunctionConverter { get; set; } =
+        new FunctionConverter(new FunctionsProvider());
+
+    public FixedValue(JToken value, FunctionConverter functionConverter = null)
     {
         Value = value;
-        this.FunctionConverter = functionConverter;
+        FunctionConverter = functionConverter ?? DefaultFunctionConverter;
     }
 
     public JToken Value { get; }

--- a/JLio.Extensions.JSchema/FilterBySchema.cs
+++ b/JLio.Extensions.JSchema/FilterBySchema.cs
@@ -21,12 +21,12 @@ public class FilterBySchema : FunctionBase
 
     public FilterBySchema(NewtonsoftJSchema schema)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(schema.ToString(),null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(schema.ToString())));
     }
 
     public FilterBySchema(string path)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(path,null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Concat.cs
+++ b/JLio.Functions/Concat.cs
@@ -16,7 +16,7 @@ public class Concat : FunctionBase
     public Concat(params string[] arguments)
     {
         arguments.ToList().ForEach(a =>
-            Arguments.Add(new FunctionSupportedValue(new FixedValue(a, null))));
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Datetime.cs
+++ b/JLio.Functions/Datetime.cs
@@ -31,7 +31,7 @@ public class Datetime : FunctionBase
     public Datetime(params string[] arguments)
     {
         arguments.ToList().ForEach(a =>
-            Arguments.Add(new FunctionSupportedValue(new FixedValue(a, null))));
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Fetch.cs
+++ b/JLio.Functions/Fetch.cs
@@ -15,7 +15,7 @@ namespace JLio.Functions
 
         public Fetch(string path)
         {
-                Arguments.Add(new FunctionSupportedValue(new FixedValue(path, null)));
+                Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
         }
 
         public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Format.cs
+++ b/JLio.Functions/Format.cs
@@ -15,13 +15,13 @@ public class Format : FunctionBase
 
     public Format(string formatString)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(formatString,null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(formatString)));
     }
 
     public Format(string path, string formatString)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""),null)));
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{formatString}\""),null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""))));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{formatString}\""))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Parse.cs
+++ b/JLio.Functions/Parse.cs
@@ -16,7 +16,7 @@ public class Parse : FunctionBase
 
     public Parse(string path)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(path, null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Partial.cs
+++ b/JLio.Functions/Partial.cs
@@ -17,7 +17,7 @@ public class Partial : FunctionBase
     public Partial(params string[] arguments)
     {
         arguments.ToList().ForEach(a =>
-            Arguments.Add(new FunctionSupportedValue(new FixedValue(a, null))));
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/Promote.cs
+++ b/JLio.Functions/Promote.cs
@@ -13,13 +13,13 @@ public class Promote : FunctionBase
 
     public Promote(string newPropertyName)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(newPropertyName, null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(newPropertyName)));
     }
 
     public Promote(string path, string newPropertyName)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""),null)));
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{newPropertyName}\""),null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{path}\""))));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(JToken.Parse($"\"{newPropertyName}\""))));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)

--- a/JLio.Functions/ToString.cs
+++ b/JLio.Functions/ToString.cs
@@ -15,7 +15,7 @@ public class ToString : FunctionBase
 
     public ToString(string path)
     {
-        Arguments.Add(new FunctionSupportedValue(new FixedValue(path, null)));
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(path)));
     }
 
     public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)


### PR DESCRIPTION
## Summary
- add static `DefaultFunctionConverter` to `FixedValue`
- use this default when a converter isn't supplied
- keep `ParseOptions.CreateDefault()` as the place that sets the default converter
- remove passing `null` for `FixedValue` in commands and functions

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68416648bf84832b84bba69be58b9881