### PR TITLE
Add builders for functions and DecisionTable

### DIFF
--- a/JLio.Commands/Builders/DecisionTableBuilders.cs
+++ b/JLio.Commands/Builders/DecisionTableBuilders.cs
@@ -1,0 +1,29 @@
+using JLio.Core.Models;
+
+namespace JLio.Commands.Builders;
+
+public static class DecisionTableBuilders
+{
+    public static DecisionTablePathContainer DecisionTable(this JLioScript source, string path)
+    {
+        return new DecisionTablePathContainer(source, path);
+    }
+
+    public static JLioScript With(this DecisionTablePathContainer source, DecisionTableConfig config)
+    {
+        source.Script.AddLine(new DecisionTable { Path = source.Path, DecisionTableConfig = config });
+        return source.Script;
+    }
+
+    public class DecisionTablePathContainer
+    {
+        public DecisionTablePathContainer(JLioScript script, string path)
+        {
+            Script = script;
+            Path = path;
+        }
+
+        internal JLioScript Script { get; }
+        internal string Path { get; }
+    }
+}

--- a/JLio.Extensions.JSchema/FilterBySchemaBuilders.cs
+++ b/JLio.Extensions.JSchema/FilterBySchemaBuilders.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json.Schema;
+
+namespace JLio.Extensions.JSchema;
+
+public static class FilterBySchemaBuilders
+{
+    public static FilterBySchema FilterBySchema(JSchema schema)
+    {
+        return new FilterBySchema(schema);
+    }
+
+    public static FilterBySchema FilterBySchema(string path)
+    {
+        return new FilterBySchema(path);
+    }
+}

--- a/JLio.Functions/Builders/ConcatBuilders.cs
+++ b/JLio.Functions/Builders/ConcatBuilders.cs
@@ -1,0 +1,11 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class ConcatBuilders
+{
+    public static Concat Concat(params string[] arguments)
+    {
+        return new Concat(arguments);
+    }
+}

--- a/JLio.Functions/Builders/DatetimeBuilders.cs
+++ b/JLio.Functions/Builders/DatetimeBuilders.cs
@@ -1,0 +1,11 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class DatetimeBuilders
+{
+    public static Datetime Datetime(params string[] arguments)
+    {
+        return new Datetime(arguments);
+    }
+}

--- a/JLio.Functions/Builders/FetchBuilders.cs
+++ b/JLio.Functions/Builders/FetchBuilders.cs
@@ -1,0 +1,11 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class FetchBuilders
+{
+    public static Fetch Fetch(string path)
+    {
+        return new Fetch(path);
+    }
+}

--- a/JLio.Functions/Builders/FormatBuilders.cs
+++ b/JLio.Functions/Builders/FormatBuilders.cs
@@ -1,0 +1,31 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class FormatBuilders
+{
+    public static Format Format(string formatString)
+    {
+        return new Format(formatString);
+    }
+
+    public static FormatPathContainer Format(string path)
+    {
+        return new FormatPathContainer(path);
+    }
+
+    public static Format UsingFormat(this FormatPathContainer source, string formatString)
+    {
+        return new Format(source.Path, formatString);
+    }
+
+    public class FormatPathContainer
+    {
+        public FormatPathContainer(string path)
+        {
+            Path = path;
+        }
+
+        internal string Path { get; }
+    }
+}

--- a/JLio.Functions/Builders/NewGuidBuilders.cs
+++ b/JLio.Functions/Builders/NewGuidBuilders.cs
@@ -1,0 +1,11 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class NewGuidBuilders
+{
+    public static NewGuid NewGuid()
+    {
+        return new NewGuid();
+    }
+}

--- a/JLio.Functions/Builders/ParseBuilders.cs
+++ b/JLio.Functions/Builders/ParseBuilders.cs
@@ -1,0 +1,16 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class ParseBuilders
+{
+    public static Parse Parse(string path)
+    {
+        return new Parse(path);
+    }
+
+    public static Parse Parse()
+    {
+        return new Parse();
+    }
+}

--- a/JLio.Functions/Builders/PartialBuilders.cs
+++ b/JLio.Functions/Builders/PartialBuilders.cs
@@ -1,0 +1,11 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class PartialBuilders
+{
+    public static Partial Partial(params string[] arguments)
+    {
+        return new Partial(arguments);
+    }
+}

--- a/JLio.Functions/Builders/PromoteBuilders.cs
+++ b/JLio.Functions/Builders/PromoteBuilders.cs
@@ -1,0 +1,16 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class PromoteBuilders
+{
+    public static Promote Promote(string newPropertyName)
+    {
+        return new Promote(newPropertyName);
+    }
+
+    public static Promote Promote(string path, string newPropertyName)
+    {
+        return new Promote(path, newPropertyName);
+    }
+}

--- a/JLio.Functions/Builders/ToStringBuilders.cs
+++ b/JLio.Functions/Builders/ToStringBuilders.cs
@@ -1,0 +1,16 @@
+using JLio.Functions;
+
+namespace JLio.Functions.Builders;
+
+public static class ToStringBuilders
+{
+    public static ToString ToString()
+    {
+        return new ToString();
+    }
+
+    public static ToString ToString(string path)
+    {
+        return new ToString(path);
+    }
+}

--- a/JLio.UnitTests/CommandsTests/AddTests.cs
+++ b/JLio.UnitTests/CommandsTests/AddTests.cs
@@ -6,6 +6,7 @@ using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -136,7 +137,7 @@ public class AddTests
         var script = new JLioScript()
                 .Add(new JValue("new Value"))
                 .OnPath("$.demo")
-                .Add(new Datetime())
+                .Add(DatetimeBuilders.Datetime())
                 .OnPath("$.this.is.a.long.path.with.a.date")
             ;
         var result = script.Execute(new JObject());

--- a/JLio.UnitTests/CommandsTests/DecisionTableTesting/DecisionTableBuilderTests.cs
+++ b/JLio.UnitTests/CommandsTests/DecisionTableTesting/DecisionTableBuilderTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using JLio.Commands.Builders;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.CommandsTests.DecisionTableTesting;
+
+public class DecisionTableBuilderTests
+{
+    [Test]
+    public void BuilderAddsCommand()
+    {
+        var config = new DecisionTableConfig
+        {
+            Inputs = new List<DecisionInput>
+            {
+                new DecisionInput { Name = "age", Path = "@.age", Type = "number" }
+            },
+            Outputs = new List<DecisionOutput>
+            {
+                new DecisionOutput { Name = "category", Path = "@.category" }
+            },
+            Rules = new List<DecisionRule>
+            {
+                new DecisionRule
+                {
+                    Conditions = new Dictionary<string, JToken> { { "age", ">=18" } },
+                    Results = new Dictionary<string, JToken> { { "category", "adult" } }
+                }
+            }
+        };
+
+        var data = JObject.Parse("{ \"person\": { \"age\": 20 } }");
+        var script = new JLioScript()
+            .DecisionTable("$.person")
+            .With(config);
+
+        var result = script.Execute(data);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("adult", result.Data.SelectToken("$.person.category")?.ToString());
+    }
+}
+

--- a/JLio.UnitTests/CommandsTests/PutTests.cs
+++ b/JLio.UnitTests/CommandsTests/PutTests.cs
@@ -6,6 +6,7 @@ using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -118,7 +119,7 @@ public class PutTests
         var script = new JLioScript()
                 .Put(new JValue("new Value"))
                 .OnPath("$.demo")
-                .Put(new Datetime())
+                .Put(DatetimeBuilders.Datetime())
                 .OnPath("$.this.is.a.long.path.with.a.date")
             ;
         var result = script.Execute(new JObject());

--- a/JLio.UnitTests/CommandsTests/SetTests.cs
+++ b/JLio.UnitTests/CommandsTests/SetTests.cs
@@ -5,6 +5,7 @@ using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System.Linq;
@@ -94,7 +95,7 @@ public class SetTests
         var script = new JLioScript()
                 .Set(new JValue("new Value"))
                 .OnPath("$.demo")
-                .Set(new Datetime())
+                .Set(DatetimeBuilders.Datetime())
                 .OnPath("$.demo2")
             ;
         var result = script.Execute(data);

--- a/JLio.UnitTests/FunctionsTests/ConcatTests.cs
+++ b/JLio.UnitTests/FunctionsTests/ConcatTests.cs
@@ -3,6 +3,7 @@ using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -55,7 +56,7 @@ public class ConcatTests
     public void CanBeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Add(new Concat("'a'", "'b'"))
+                .Add(ConcatBuilders.Concat("'a'", "'b'"))
                 .OnPath("$.result")
             ;
         var result = script.Execute(new JObject());
@@ -70,7 +71,7 @@ public class ConcatTests
     public void CanbeUsedInFluentApi_Set()
     {
         var script = new JLioScript()
-            .Set(new Concat("'a'", "'b'"))
+            .Set(ConcatBuilders.Concat("'a'", "'b'"))
             .OnPath("$.demo");
         var result = script.Execute(JToken.Parse("{\"demo\":{\"pageIndex\":5,\"shouldBeRemoved\":true}}"));
 

--- a/JLio.UnitTests/FunctionsTests/DatetimeFunctionTests.cs
+++ b/JLio.UnitTests/FunctionsTests/DatetimeFunctionTests.cs
@@ -3,6 +3,7 @@ using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -44,9 +45,9 @@ public class DatetimeFunctionTests
     public void CanbeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Add(new Datetime("UTC", "'dd-MM-yyyy HH:mm:ss'"))
+                .Add(DatetimeBuilders.Datetime("UTC", "'dd-MM-yyyy HH:mm:ss'"))
                 .OnPath("$.date")
-                .Add(new Datetime("'HH:mm:ss'"))
+                .Add(DatetimeBuilders.Datetime("'HH:mm:ss'"))
                 .OnPath("$.now")
             ;
         var result = script.Execute(new JObject());

--- a/JLio.UnitTests/FunctionsTests/FilterBySchemaTests.cs
+++ b/JLio.UnitTests/FunctionsTests/FilterBySchemaTests.cs
@@ -41,7 +41,7 @@ public class FilterBySchemaTests
         var parsedSchema = JSchema.Parse(schema);
 
         var script = new JLioScript()
-            .Set(new FilterBySchema(parsedSchema))
+            .Set(FilterBySchemaBuilders.FilterBySchema(parsedSchema))
             .OnPath("$.demo");
         var result = script.Execute(JToken.Parse(
             "{\"demo\":{\"points\":\"dolor Excepteur aliquip in\",\"viewState\":{\"sintc\":false,\"velit_c3\":\"dolore Ut\",\"aliquab84\":98258463,\"tempor_0\":true,\"amet_54\":true,\"sunt_c\":\"exercitation Excepteur ipsum\",\"ex_16\":9425019.714207217,\"do_11e\":false},\"something\":[{\"loc\":\"dolor et Excepteur exercitation\",\"toll\":\"ad elit esse adipisicing\",\"message\":\"tempor est\"},{\"loc\":\"veniam do fugiat labore eiusmod\",\"toll\":\"dolore aliqua veniam sit\",\"message\":\"aliquip ad do irure velit\"},{\"loc\":\"et\"},{\"loc\":\"dolore non dolore sint\",\"toll\":\"minim ut consectetur fugiat\",\"message\":\"cillum exercitation quis id laborum\"}]  }}"));
@@ -54,7 +54,7 @@ public class FilterBySchemaTests
     public void CanBeUsedInFluentApi_SchemaPath()
     {
         var script = new JLioScript()
-            .Set(new FilterBySchema("$.schema"))
+            .Set(FilterBySchemaBuilders.FilterBySchema("$.schema"))
             .OnPath("$.demo");
         var result = script.Execute(JToken.Parse(
             "{\"schema\":{\"type\":\"object\",\"description\":\"The point of interest location description.\",\"properties\":{\"pageIndex\":{\"type\":\"number\",\"description\":\"The page index to view\"},\"points\":{\"description\":\"Used if viewState.zoomWidth is true; specifies 4 corners of the rectangle to make visible.\",\"type\":\"string\"},\"something\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"loc\":{\"type\":\"string\"},\"toll\":{\"type\":\"string\"},\"message\":{\"type\":\"string\"}},\"required\":[\"loc\"]}},\"viewState\":{\"type\":\"object\",\"description\":\"The view state information\",\"properties\":{\"hasViewState\":{\"type\":\"boolean\",\"description\":\"Whether there is view state information to use\"},\"rotate\":{\"type\":\"number\",\"description\":\"Degrees of rotation\"},\"extents\":{\"type\":\"boolean\",\"description\":\"Whether the view should scale to fit extents or not\"},\"zoomWidth\":{\"type\":\"boolean\",\"description\":\"Whether the view should scale to fit width or not\"},\"scaleFactor\":{\"type\":\"number\",\"description\":\"The scale factor for the view state\"},\"deviceRect\":{\"type\":\"object\",\"description\":\"The device rectangle geometry\",\"properties\":{\"left\":{\"type\":\"number\",\"description\":\"The left edge of the device rectangle\"},\"right\":{\"type\":\"number\",\"description\":\"The right edge of the device rectangle\"},\"top\":{\"type\":\"number\",\"description\":\"The top edge of the device rectangle\"},\"bottom\":{\"type\":\"number\",\"description\":\"The bottom edge of the device rectangle\"}}},\"eyePoint\":{\"type\":\"object\",\"description\":\"The eyepoint coordinate\",\"properties\":{\"x\":{\"type\":\"number\",\"description\":\"The x coordinate of the eyepoint\"},\"y\":{\"type\":\"number\",\"description\":\"The y coordinate of the eyepoint\"}}}}}}},\"demo\":{\"pageIndex\":5,\"shouldBeRemoved\":true}}"));

--- a/JLio.UnitTests/FunctionsTests/FormatTests.cs
+++ b/JLio.UnitTests/FunctionsTests/FormatTests.cs
@@ -3,6 +3,7 @@ using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -51,9 +52,9 @@ public class FormatTests
     public void CanBeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Set(new Format("$.demo2", "dd-MM"))
+                .Set(FormatBuilders.Format("$.demo2").UsingFormat("dd-MM"))
                 .OnPath("$.id")
-                .Set(new Format("dd-MM-yyyy"))
+                .Set(FormatBuilders.Format("dd-MM-yyyy"))
                 .OnPath("$.demo")
             ;
         var result =

--- a/JLio.UnitTests/FunctionsTests/NewGuidTests.cs
+++ b/JLio.UnitTests/FunctionsTests/NewGuidTests.cs
@@ -4,6 +4,7 @@ using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -39,7 +40,7 @@ public class NewGuidTests
     public void CanbeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Add(new NewGuid())
+                .Add(NewGuidBuilders.NewGuid())
                 .OnPath("$.id")
             ;
         var result = script.Execute(new JObject());

--- a/JLio.UnitTests/FunctionsTests/ParseTests.cs
+++ b/JLio.UnitTests/FunctionsTests/ParseTests.cs
@@ -5,6 +5,7 @@ using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Extensions.JSchema;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -78,9 +79,9 @@ public class ParseTests
     public void CanbeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Set(new Parse())
+                .Set(ParseBuilders.Parse())
                 .OnPath("$.id")
-                .Add(new Parse("$.id"))
+                .Add(ParseBuilders.Parse("$.id"))
                 .OnPath("$.result")
             ;
         var result = script.Execute(JObject.Parse("{\"id\" : \"3\" }"));

--- a/JLio.UnitTests/FunctionsTests/PartialTests.cs
+++ b/JLio.UnitTests/FunctionsTests/PartialTests.cs
@@ -4,6 +4,7 @@ using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -123,7 +124,7 @@ public class PartialTests
     public void CanBeUsedInFluentApi()
     {
         var script = new JLioScript()
-            .Set(new Partial("@.a", "@.c.d"))
+            .Set(PartialBuilders.Partial("@.a", "@.c.d"))
             .OnPath("$.result");
         var result =
             script.Execute(JToken.Parse("{\"result\":{\"a\":1,\"b\":[1,2,3],\"c\":{\"d\":5,\"e\":[4,5,6]}}}"));

--- a/JLio.UnitTests/FunctionsTests/PromoteTests.cs
+++ b/JLio.UnitTests/FunctionsTests/PromoteTests.cs
@@ -4,6 +4,7 @@ using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -71,9 +72,9 @@ public class PromoteTests
     public void CanBeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Set(new Promote("$.demo", "new"))
+                .Set(PromoteBuilders.Promote("$.demo", "new"))
                 .OnPath("$.id")
-                .Set(new Promote("newer"))
+                .Set(PromoteBuilders.Promote("newer"))
                 .OnPath("$.demo")
             ;
         var result = script.Execute(JToken.Parse("{\"demo\" : 1}"));

--- a/JLio.UnitTests/FunctionsTests/ToStringTests.cs
+++ b/JLio.UnitTests/FunctionsTests/ToStringTests.cs
@@ -3,6 +3,7 @@ using JLio.Commands.Builders;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using JLio.Functions;
+using JLio.Functions.Builders;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -54,9 +55,9 @@ public class ToStringTests
     public void CanbeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Set(new ToString())
+                .Set(ToStringBuilders.ToString())
                 .OnPath("$.id")
-                .Set(new ToString("$.result"))
+                .Set(ToStringBuilders.ToString("$.result"))
                 .OnPath("$.resultDemo")
             ;
         var result = script.Execute(JObject.Parse("{\"result\" : 3 }"));


### PR DESCRIPTION
## Summary
- add builder extensions for DecisionTable command
- add builder helpers for functions and FilterBySchema
- update unit tests to use the new builders
- cover new DecisionTable builder with a dedicated test

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6841757bf164832b81fea7b734a5806c