### PR TITLE
Add avg and count math functions

### DIFF
--- a/JLio.Extensions.Math/Avg.cs
+++ b/JLio.Extensions.Math/Avg.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Extensions.Math;
+
+public class Avg : FunctionBase
+{
+    public Avg()
+    {
+    }
+
+    public Avg(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        double sum = 0;
+        int count = 0;
+
+        foreach (var token in values)
+        {
+            if (!TryAddTokenValue(token, ref sum, ref count, context))
+            {
+                return JLioFunctionResult.Failed(currentToken);
+            }
+        }
+
+        var result = count == 0 ? 0 : sum / count;
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+
+    private bool TryAddTokenValue(JToken token, ref double sum, ref int count, IExecutionContext context)
+    {
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                sum += token.Value<double>();
+                count++;
+                return true;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), out var numeric):
+                sum += numeric;
+                count++;
+                return true;
+
+            case JTokenType.Array:
+                return TryAddArrayValues((JArray)token, ref sum, ref count, context);
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values or arrays. Current type = {token.Type}");
+                return false;
+        }
+    }
+
+    private bool TryAddArrayValues(JArray array, ref double sum, ref int count, IExecutionContext context)
+    {
+        foreach (var item in array)
+        {
+            if (!TryAddTokenValue(item, ref sum, ref count, context))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/JLio.Extensions.Math/Builders/AvgBuilders.cs
+++ b/JLio.Extensions.Math/Builders/AvgBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class AvgBuilders
+{
+    public static Avg Avg(params string[] arguments)
+    {
+        return new Avg(arguments);
+    }
+}

--- a/JLio.Extensions.Math/Builders/CountBuilders.cs
+++ b/JLio.Extensions.Math/Builders/CountBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class CountBuilders
+{
+    public static Count Count(params string[] arguments)
+    {
+        return new Count(arguments);
+    }
+}

--- a/JLio.Extensions.Math/Count.cs
+++ b/JLio.Extensions.Math/Count.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Extensions.Math;
+
+public class Count : FunctionBase
+{
+    public Count()
+    {
+    }
+
+    public Count(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        int count = 0;
+
+        foreach (var token in values)
+        {
+            AddToken(token, ref count);
+        }
+
+        return new JLioFunctionResult(true, new JValue(count));
+    }
+
+    private void AddToken(JToken token, ref int count)
+    {
+        switch (token.Type)
+        {
+            case JTokenType.Array:
+                count += token.Count();
+                break;
+            case JTokenType.Object:
+                count += ((JObject)token).Properties().Count();
+                break;
+            default:
+                count++;
+                break;
+        }
+    }
+}

--- a/JLio.Extensions.Math/RegisterMathPack.cs
+++ b/JLio.Extensions.Math/RegisterMathPack.cs
@@ -12,6 +12,8 @@ namespace JLio.Extensions.Math
         public static IParseOptions RegisterMath(this IParseOptions parseOptions)
         {
             parseOptions.RegisterFunction<Sum>();
+            parseOptions.RegisterFunction<Avg>();
+            parseOptions.RegisterFunction<Count>();
             return parseOptions;
         }
     }

--- a/JLio.UnitTests/FunctionsTests/AvgTests.cs
+++ b/JLio.UnitTests/FunctionsTests/AvgTests.cs
@@ -1,0 +1,53 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class AvgTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=avg()", "{}", 0)]
+    [TestCase("=avg(1,2,3)", "{}", 2)]
+    [TestCase("=avg($.a,$.b,$.c)", "{\"a\":1,\"b\":2,\"c\":3}", 2)]
+    [TestCase("=avg($.numbers[*])", "{\"numbers\":[4,6]}", 5)]
+    public void avgTests(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(AvgBuilders.Avg("1", "3"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(2, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/CountTests.cs
+++ b/JLio.UnitTests/FunctionsTests/CountTests.cs
@@ -1,0 +1,55 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class CountTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=count()", "{}", 0)]
+    [TestCase("=count(1,2,3)", "{}", 3)]
+    [TestCase("=count($.a,$.b)", "{\"a\":1,\"b\":2}", 2)]
+    [TestCase("=count($.numbers)", "{\"numbers\":[1,2,3]}", 3)]
+    [TestCase("=count($.obj)", "{\"obj\":{\"a\":1,\"b\":2}}", 2)]
+    public void countTests(string function, string data, int resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<int>());
+    }
+
+    [Test]
+    public void CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(CountBuilders.Count("$.items"))
+                .OnPath("$.count");
+        var token = JToken.Parse("{\"items\":[1,2,3]}");
+        var result = script.Execute(token);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(3, result.Data.SelectToken("$.count")?.Value<int>());
+    }
+}


### PR DESCRIPTION
## Summary
- add Avg and Count math functions with builders
- register Avg and Count functions
- test Avg and Count behavior

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842d1321cfc832ba1a207b9dfdaac5c