### PR TITLE
Add more unit tests for coverage

### DIFF
--- a/JLio.UnitTests/CommandsTests/DecisionTableTesting/DecisionTableJsonParseTests.cs
+++ b/JLio.UnitTests/CommandsTests/DecisionTableTesting/DecisionTableJsonParseTests.cs
@@ -1,0 +1,19 @@
+using JLio.Client;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.CommandsTests.DecisionTableTesting;
+
+public class DecisionTableJsonParseTests
+{
+    [Test]
+    public void ParseDecisionTableScriptAndExecute()
+    {
+        var script = "[{\"command\":\"decisionTable\",\"path\":\"$.person\",\"decisionTable\":{\"inputs\":[{\"name\":\"age\",\"path\":\"@.age\"}],\"outputs\":[{\"name\":\"category\",\"path\":\"@.category\"}],\"rules\":[{\"conditions\":{\"age\":\">=18\"},\"results\":{\"category\":\"adult\"}}]}}]";
+        var scriptObj = JLioConvert.Parse(script);
+        var data = JObject.Parse("{\"person\":{\"age\":20}}");
+        var result = scriptObj.Execute(data);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("adult", data.SelectToken("$.person.category")?.ToString());
+    }
+}

--- a/JLio.UnitTests/ExecutionLoggerTests.cs
+++ b/JLio.UnitTests/ExecutionLoggerTests.cs
@@ -1,0 +1,22 @@
+using JLio.Core.Models;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System.Text.RegularExpressions;
+
+namespace JLio.UnitTests;
+
+public class ExecutionLoggerTests
+{
+    [Test]
+    public void LogTextFormatsEntries()
+    {
+        var logger = new ExecutionLogger();
+        logger.Log(LogLevel.Information, "group1", "first");
+        logger.Log(LogLevel.Warning, "group2", "second");
+
+        var lines = logger.LogText.Trim().Split('\n');
+        Assert.AreEqual(2, lines.Length);
+        StringAssert.IsMatch(@"\d{2}:\d{2}:\d{2}\.\d{3}\s+Information - first", lines[0]);
+        StringAssert.IsMatch(@"\d{2}:\d{2}:\d{2}\.\d{3}\s+Warning - second", lines[1]);
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/AvgErrorTests.cs
+++ b/JLio.UnitTests/FunctionsTests/AvgErrorTests.cs
@@ -1,0 +1,22 @@
+using JLio.Client;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class AvgErrorTests
+{
+    [Test]
+    public void AvgLogsErrorForInvalidType()
+    {
+        var options = ParseOptions.CreateDefault().RegisterMath();
+        var context = ExecutionContext.CreateDefault();
+        var script = "[{'path':'$.result','value':'=avg($.obj)','command':'add'}]".Replace("'","\"");
+        var result = JLioConvert.Parse(script, options).Execute(JObject.Parse("{ 'obj': { 'a': 1 } }".Replace("'","\"")), context);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(context.GetLogEntries().Any(e => e.Message.Contains("can only handle numeric values")));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/FetchBuildersTests.cs
+++ b/JLio.UnitTests/FunctionsTests/FetchBuildersTests.cs
@@ -1,0 +1,21 @@
+using JLio.Commands.Builders;
+using JLio.Core.Models;
+using JLio.Functions.Builders;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class FetchBuildersTests
+{
+    [Test]
+    public void BuilderCreatesFetchFunction()
+    {
+        var script = new JLioScript()
+            .Add(FetchBuilders.Fetch("$.value"))
+            .OnPath("$.result");
+        var result = script.Execute(JObject.Parse("{\"value\":5}"));
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(5, result.Data.SelectToken("$.result")!.Value<int>());
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/RegisterExtensionsTests.cs
+++ b/JLio.UnitTests/FunctionsTests/RegisterExtensionsTests.cs
@@ -1,0 +1,24 @@
+using JLio.Core;
+using JLio.Extensions.JSchema;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class RegisterExtensionsTests
+{
+    [Test]
+    public void RegisterJSchemaFunctionsRegistersFilterBySchema()
+    {
+        var provider = new FunctionsProvider();
+        provider.RegisterJSchemaFunctions();
+        Assert.IsNotNull(provider["filterBySchema"]);
+    }
+
+    [Test]
+    public void RegisterFilterByJSchemaFunctionRegistersFilterBySchema()
+    {
+        var provider = new FunctionsProvider();
+        provider.RegisterFilterByJSchemaFunction();
+        Assert.IsNotNull(provider["filterBySchema"]);
+    }
+}


### PR DESCRIPTION
## Summary
- add parsing test for decision tables
- test Fetch builder
- test logging text output
- test extension registration helpers
- ensure Avg function logs error for invalid types

## Testing
- `dotnet test JLio.UnitTests/JLio.UnitTests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_b_6842d612f9e4832b8c5a08dfb42b43b1