### PR TITLE
Increase coverage for helpers and schema utilities

### DIFF
--- a/JLio.UnitTests/CoreTests/JLioExecutionResultTests.cs
+++ b/JLio.UnitTests/CoreTests/JLioExecutionResultTests.cs
@@ -1,0 +1,35 @@
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.CoreTests;
+
+public class JLioExecutionResultTests
+{
+    [Test]
+    public void ConstructorSetsProperties()
+    {
+        var token = JToken.Parse("{\"a\":1}");
+        var result = new JLioExecutionResult(true, token);
+        Assert.IsTrue(result.Success);
+        Assert.AreSame(token, result.Data);
+    }
+
+    [Test]
+    public void FailedCreatesFailedResult()
+    {
+        var token = new JObject();
+        var result = JLioExecutionResult.Failed(token);
+        Assert.IsFalse(result.Success);
+        Assert.AreSame(token, result.Data);
+    }
+
+    [Test]
+    public void SuccessFulCreatesSuccessfulResult()
+    {
+        var token = new JObject();
+        var result = JLioExecutionResult.SuccessFul(token);
+        Assert.IsTrue(result.Success);
+        Assert.AreSame(token, result.Data);
+    }
+}

--- a/JLio.UnitTests/CoreTests/NamingsHelperTests.cs
+++ b/JLio.UnitTests/CoreTests/NamingsHelperTests.cs
@@ -1,0 +1,17 @@
+using JLio.Core.Extensions;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.CoreTests;
+
+public class NamingsHelperTests
+{
+    [TestCase("Hello", "hello")]
+    [TestCase("hello", "hello")]
+    [TestCase("", "")]
+    [TestCase(null, null)]
+    public void CamelCasingReturnsExpected(string input, string expected)
+    {
+        var result = NamingsHelper.CamelCasing(input);
+        Assert.AreEqual(expected, result);
+    }
+}

--- a/JLio.UnitTests/ExtensionsTests/JSchemaExtensionsTests.cs
+++ b/JLio.UnitTests/ExtensionsTests/JSchemaExtensionsTests.cs
@@ -1,0 +1,23 @@
+using JLio.Extensions.JSchema;
+using Newtonsoft.Json.Schema;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.ExtensionsTests;
+
+public class JSchemaExtensionsTests
+{
+    [Test]
+    public void GetPathsWithMultipleArrayItemsUsesIndexPaths()
+    {
+        var schemaJson = "{ 'type':'array', 'items': [ { 'type':'string' }, { 'type':'number' } ] }".Replace('\'', '"');
+        var schema = JSchema.Parse(schemaJson);
+        var result = schema.GetPaths();
+
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual(SchemaPropertyType.Array, result[0].Type);
+        Assert.AreEqual("$", result[0].Path);
+        Assert.IsTrue(result.Any(p => p.Path == "$[0]" && p.Type == SchemaPropertyType.Primitive));
+        Assert.IsTrue(result.Any(p => p.Path == "$[1]" && p.Type == SchemaPropertyType.Primitive));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/FormatTests.cs
+++ b/JLio.UnitTests/FunctionsTests/FormatTests.cs
@@ -84,4 +84,26 @@ public class FormatTests
         Assert.IsFalse(result.Success);
         Assert.IsTrue(executeContext.Logger.LogEntries.Any(i => i.Level == LogLevel.Error));
     }
+
+    [Test]
+    public void FormatLeavesNonDateStringUnchanged()
+    {
+        var token = JObject.Parse("{\"source\":\"not a date\"}");
+        var function = "=format($.source,'dd-MM-yyyy')";
+        var script = $"[{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(token, executeContext);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("not a date", result.Data.SelectToken("$.result")?.Value<string>());
+    }
+
+    [Test]
+    public void FormatLeavesNumericValueUnchanged()
+    {
+        var token = JObject.Parse("{\"source\":123}");
+        var function = "=format($.source,'dd-MM-yyyy')";
+        var script = $"[{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(token, executeContext);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(123, result.Data.SelectToken("$.result")?.Value<int>());
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests for `JLioExecutionResult` and `NamingsHelper`
- cover more `Format` scenarios where the value is not a date
- test `GetPaths` array indexing behaviour in `JSchemaExtensions`

## Testing
- `dotnet build JLio.sln`
- `dotnet test JLio.UnitTests/JLio.UnitTests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_b_6842e7fe9cd4832b99ffc36104e096d7