### PR TITLE
Implement IfElse command

### DIFF
--- a/JLio.CLient/ParseOptions.cs
+++ b/JLio.CLient/ParseOptions.cs
@@ -38,7 +38,8 @@ public class ParseOptions : IParseOptions
            .Register<Move>()
            .Register<Compare>()
            .Register<Merge>()
-           .Register<DecisionTable>();
+           .Register<DecisionTable>()
+           .Register<IfElse>();
 
         var functionsProvider = new FunctionsProvider();
         functionsProvider

--- a/JLio.Commands/IfElse.cs
+++ b/JLio.Commands/IfElse.cs
@@ -1,0 +1,55 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Extensions;
+using JLio.Core.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Commands;
+
+public class IfElse : CommandBase
+{
+    [JsonProperty("first")]
+    public IFunctionSupportedValue First { get; set; }
+
+    [JsonProperty("second")]
+    public IFunctionSupportedValue Second { get; set; }
+
+    [JsonProperty("ifScript")]
+    public JLioScript IfScript { get; set; }
+
+    [JsonProperty("elseScript")]
+    public JLioScript ElseScript { get; set; }
+
+    public override JLioExecutionResult Execute(JToken dataContext, IExecutionContext context)
+    {
+        var validation = ValidateCommandInstance();
+        if (!validation.IsValid)
+        {
+            validation.ValidationMessages.ForEach(m => context.LogWarning(CoreConstants.CommandExecution, m));
+            return new JLioExecutionResult(false, dataContext);
+        }
+
+        var firstValue = First.GetValue(dataContext, dataContext, context).Data.GetJTokenValue();
+        var secondValue = Second.GetValue(dataContext, dataContext, context).Data.GetJTokenValue();
+
+        if (JToken.DeepEquals(firstValue, secondValue))
+        {
+            return IfScript?.Execute(dataContext, context) ?? JLioExecutionResult.SuccessFul(dataContext);
+        }
+
+        return ElseScript?.Execute(dataContext, context) ?? JLioExecutionResult.SuccessFul(dataContext);
+    }
+
+    public override ValidationResult ValidateCommandInstance()
+    {
+        var result = new ValidationResult();
+        if (First == null)
+            result.ValidationMessages.Add($"First property for {CommandName} command is missing");
+        if (Second == null)
+            result.ValidationMessages.Add($"Second property for {CommandName} command is missing");
+        if (IfScript == null)
+            result.ValidationMessages.Add($"IfScript property for {CommandName} command is missing");
+        return result;
+    }
+}

--- a/JLio.UnitTests/CommandsTests/IfElseTests.cs
+++ b/JLio.UnitTests/CommandsTests/IfElseTests.cs
@@ -1,0 +1,95 @@
+using JLio.Client;
+using JLio.Commands;
+using JLio.Commands.Builders;
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.CommandsTests;
+
+public class IfElseTests
+{
+    private IExecutionContext executeOptions;
+    private FunctionConverter functionConverter;
+
+    [SetUp]
+    public void Setup()
+    {
+        executeOptions = ExecutionContext.CreateDefault();
+        functionConverter = new FunctionConverter(ParseOptions.CreateDefault().FunctionsProvider);
+    }
+
+    private IFunctionSupportedValue Val(JToken v) => new FunctionSupportedValue(new FixedValue(v, functionConverter));
+
+    [Test]
+    public void ExecutesIfBranchWhenConditionMatches()
+    {
+        var data = JObject.Parse("{\"aaa\":{\"bb\":[{\"revenue\":200}]},\"result\":0}");
+        var ifScript = new JLioScript()
+            .Set(new JValue(1))
+            .OnPath("$.result");
+        var elseScript = new JLioScript()
+            .Set(new JValue(-1))
+            .OnPath("$.result");
+
+        var command = new IfElse
+        {
+            First = Val(new JValue("$.aaa.bb[0].revenue")),
+            Second = Val(new JValue(200)),
+            IfScript = ifScript,
+            ElseScript = elseScript
+        };
+
+        var script = new JLioScript();
+        script.AddLine(command);
+
+        var result = script.Execute(data, executeOptions);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, data.SelectToken("$.result")?.Value<int>());
+    }
+
+    [Test]
+    public void ExecutesElseBranchWhenConditionDoesNotMatch()
+    {
+        var data = JObject.Parse("{\"aaa\":{\"bb\":[{\"revenue\":100}]},\"result\":0}");
+        var ifScript = new JLioScript()
+            .Set(new JValue(1))
+            .OnPath("$.result");
+        var elseScript = new JLioScript()
+            .Set(new JValue(-1))
+            .OnPath("$.result");
+
+        var command = new IfElse
+        {
+            First = Val(new JValue("$.aaa.bb[0].revenue")),
+            Second = Val(new JValue(200)),
+            IfScript = ifScript,
+            ElseScript = elseScript
+        };
+
+        var script = new JLioScript();
+        script.AddLine(command);
+
+        var result = script.Execute(data, executeOptions);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(-1, data.SelectToken("$.result")?.Value<int>());
+    }
+
+    [Test]
+    public void CanParseWithNestedScripts()
+    {
+        var scriptText = "[{\"first\":\"$.value\",\"second\":1,\"ifScript\":[{\"path\":\"$.result\",\"value\":\"if\",\"command\":\"add\"}],\"elseScript\":[{\"path\":\"$.result\",\"value\":\"else\",\"command\":\"add\"}],\"command\":\"ifElse\"}]";
+
+        var script = JLioConvert.Parse(scriptText);
+
+        var data = JObject.Parse("{\"value\":1}");
+        var result = script.Execute(data, executeOptions);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("if", data.SelectToken("$.result")?.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- add new `IfElse` command to execute different scripts based on a comparison
- register the command in default `ParseOptions`
- add unit tests covering execution and parsing of nested scripts

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test JLio.sln`

------
https://chatgpt.com/codex/tasks/task_b_6842ef0ccc7c832b92cce9532ba6b147