### PR TITLE
Add JLio documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 JLio (jay-lio) is a structured language definition for transforming JSON objects using a transformation script with a JSON notation. 
 
+For detailed documentation see [doc/README.md](doc/README.md).
+
 JLio can create and alter JSON data objects. It allows the transformation of objects, without having the need to code or develop logic. Simply writing the desired commands as a JSON object. Executing the script on a data object will transform the data object following the script commands.
 
 Designed with extensibility in mind, commands, and functions can be added to support the desired functionality. 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,8 @@
+# JLio Documentation
+
+Welcome to the JLio documentation. This section contains detailed information about using the JLio scripting language and its .NET implementation.
+
+- [General Concepts](general.md)
+- [Commands](commands.md)
+- [Functions](functions.md)
+- [Advanced Scenarios](advanced.md)

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -1,0 +1,25 @@
+# Advanced Scenarios
+
+JLio supports advanced scripting features such as nested functions and conditional execution.
+
+## Nested Functions
+
+Functions can be combined by using the result of one function as the argument of another. For example:
+
+```json
+{
+  "path": "$.demo",
+  "value": "=toString(parse($.raw))",
+  "command": "add"
+}
+```
+
+## Conditional Execution
+
+Use the `ifElse` command to execute different scripts based on a condition. Each branch contains a nested script.
+
+## Decision Tables
+
+The `decisionTable` command allows mapping a value to a script. Depending on the input value a particular command set will be executed.
+
+These capabilities enable complex transformation strategies.

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1,0 +1,30 @@
+# Commands
+
+A JLio script is an array of command definitions. Each command has a `command` property that names the action and other properties that configure the action.
+
+## Structure
+
+```json
+{
+  "path": "$.target.path",
+  "value": "some value",
+  "command": "add"
+}
+```
+
+The table below lists the available commands and their main arguments.
+
+| Command | Arguments | Description |
+|---|---|---|
+| **add** | `path`, `value` | Add a property or append to an array. |
+| **set** | `path`, `value` | Replace an existing value. |
+| **copy** | `path`, `from` | Copy a value from one location to another. |
+| **move** | `path`, `from` | Move a value from one location to another. |
+| **put** | `path`, `value` | Create a value only when the target does not exist. |
+| **remove** | `path` | Remove a property or array element. |
+| **decisionTable** | custom | Execute commands based on a lookup. |
+| **ifElse** | `condition`, `then`, `else` | Execute nested scripts conditionally. |
+| **merge** | `path`, `value` | Merge objects and arrays. |
+| **compare** | `path`, `value` | Compare two values according to settings. |
+
+Arguments can reference JSONPath locations and may use functions in the `value` field.

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -1,0 +1,27 @@
+# Functions
+
+Functions can be used in command arguments by prefixing the value with `=`. Nesting functions is supported.
+
+A function call has the format `=functionName(arg1, arg2)`.
+
+| Function | Arguments | Description |
+|---|---|---|
+| **concat** | `values...` | Concatenate elements into a string. |
+| **datetime** | `time`, `format` | Return the current time in optional format. |
+| **fetch** | `url` | Load external JSON. |
+| **format** | `value`, `pattern` | Apply string formatting. |
+| **newGuid** | *(none)* | Generate a GUID value. |
+| **parse** | `jsonpath?` | Parse a string into JSON. |
+| **partial** | `jsonpath` | Extract part of a JSON structure. |
+| **promote** | `jsonpath` | Move a child element up one level. |
+| **toString** | `jsonpath?` | Convert a value to a string. |
+
+Example usage inside a command:
+
+```json
+{
+  "path": "$.demo",
+  "value": "=parse($.source)",
+  "command": "set"
+}
+```

--- a/doc/general.md
+++ b/doc/general.md
@@ -1,0 +1,46 @@
+# General Concepts
+
+JLio is a language for describing JSON transformations. A script is composed of commands, each command altering the JSON data.
+
+## Parsing Scripts
+
+Scripts are written in JSON notation. They can be parsed into a `JLioScript` object using the `JLioConvert.Parse` method:
+
+```csharp
+var script = JLioConvert.Parse(scriptText);
+```
+
+Scripts can also be constructed using the fluent API:
+
+```csharp
+var script = new JLioScript()
+                .Add(new JValue("new Value"))
+                .OnPath("$.demo")
+                .Add(new Datetime())
+                .OnPath("$.this.is.a.long.path.with.a.date");
+```
+
+Executing the script applies the commands to a `JToken` data object:
+
+```csharp
+var data = JToken.Parse("{\"demoText\":\"Hello World\"}");
+var result = script.Execute(data);
+```
+
+## JSONPath Basics
+
+JLio uses [JSONPath](https://goessner.net/articles/JsonPath/) to select elements in the data object.
+
+| Notation | Description |
+|---|---|
+| `$` | the root element |
+| `@` | the current element |
+| `.` or `[]` | child operator |
+| `..` | recursive descent |
+| `*` | wildcard |
+| `[]` | array subscript |
+| `[,]` | union operator |
+| `[start:end:step]` | array slice |
+| `?()` | filter expression |
+
+JSONPath expressions can be combined to select nodes and filter results.


### PR DESCRIPTION
## Summary
- add documentation folder with docs on concepts, commands, functions, and advanced scenarios
- link main README to new doc folder

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842f3d5641c832b8049f2e9f3749452