### PR TITLE
Add per-command and per-function docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -6,3 +6,5 @@ Welcome to the JLio documentation. This section contains detailed information ab
 - [Commands](commands.md)
 - [Functions](functions.md)
 - [Advanced Scenarios](advanced.md)
+
+Detailed files for every command are in [commands/](commands) and each function in [functions/](functions).

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -28,3 +28,16 @@ The table below lists the available commands and their main arguments.
 | **compare** | `path`, `value` | Compare two values according to settings. |
 
 Arguments can reference JSONPath locations and may use functions in the `value` field.
+
+## Command details
+
+- [add](commands/add.md)
+- [set](commands/set.md)
+- [copy](commands/copy.md)
+- [move](commands/move.md)
+- [put](commands/put.md)
+- [remove](commands/remove.md)
+- [decisionTable](commands/decisionTable.md)
+- [ifElse](commands/ifElse.md)
+- [merge](commands/merge.md)
+- [compare](commands/compare.md)

--- a/doc/commands/add.md
+++ b/doc/commands/add.md
@@ -1,0 +1,7 @@
+# add
+
+Adds a property to an object or appends to an array.
+
+## Arguments
+- `path` – JSONPath of the target location.
+- `value` – value to add (supports functions).

--- a/doc/commands/compare.md
+++ b/doc/commands/compare.md
@@ -1,0 +1,7 @@
+# compare
+
+Compares two values according to settings.
+
+## Arguments
+- `path` – JSONPath of the target location.
+- `value` – value to compare against.

--- a/doc/commands/copy.md
+++ b/doc/commands/copy.md
@@ -1,0 +1,7 @@
+# copy
+
+Copies a value from one location to another.
+
+## Arguments
+- `from` – JSONPath of the source value.
+- `path` – JSONPath of the target location.

--- a/doc/commands/decisionTable.md
+++ b/doc/commands/decisionTable.md
@@ -1,0 +1,6 @@
+# decisionTable
+
+Executes different scripts based on a lookup table.
+
+## Arguments
+- custom arguments depending on the table configuration.

--- a/doc/commands/ifElse.md
+++ b/doc/commands/ifElse.md
@@ -1,0 +1,8 @@
+# ifElse
+
+Conditionally executes nested scripts.
+
+## Arguments
+- `condition` – expression to evaluate.
+- `then` – commands when condition is true.
+- `else` – commands when condition is false.

--- a/doc/commands/merge.md
+++ b/doc/commands/merge.md
@@ -1,0 +1,7 @@
+# merge
+
+Merges objects or arrays together.
+
+## Arguments
+- `path` – JSONPath of the target location.
+- `value` – object or array to merge.

--- a/doc/commands/move.md
+++ b/doc/commands/move.md
@@ -1,0 +1,7 @@
+# move
+
+Moves a value from one location to another. The source value is removed after copying.
+
+## Arguments
+- `from` – JSONPath of the source value.
+- `path` – JSONPath of the target location.

--- a/doc/commands/put.md
+++ b/doc/commands/put.md
@@ -1,0 +1,7 @@
+# put
+
+Creates a value only when the target does not already exist.
+
+## Arguments
+- `path` – JSONPath of the target location.
+- `value` – value to write (supports functions).

--- a/doc/commands/remove.md
+++ b/doc/commands/remove.md
@@ -1,0 +1,6 @@
+# remove
+
+Removes a property or array element.
+
+## Arguments
+- `path` – JSONPath of the element to remove.

--- a/doc/commands/set.md
+++ b/doc/commands/set.md
@@ -1,0 +1,7 @@
+# set
+
+Replaces the value at the target path.
+
+## Arguments
+- `path` – JSONPath of the target location.
+- `value` – new value (supports functions).

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -25,3 +25,19 @@ Example usage inside a command:
   "command": "set"
 }
 ```
+
+## Function details
+
+- [concat](functions/concat.md)
+- [datetime](functions/datetime.md)
+- [fetch](functions/fetch.md)
+- [format](functions/format.md)
+- [newGuid](functions/newGuid.md)
+- [parse](functions/parse.md)
+- [partial](functions/partial.md)
+- [promote](functions/promote.md)
+- [toString](functions/toString.md)
+- [avg](functions/avg.md)
+- [count](functions/count.md)
+- [sum](functions/sum.md)
+- [filterBySchema](functions/filterBySchema.md)

--- a/doc/functions/avg.md
+++ b/doc/functions/avg.md
@@ -1,0 +1,6 @@
+# avg
+
+Calculates the average of numeric arguments.
+
+## Arguments
+- one or more numeric values or arrays.

--- a/doc/functions/concat.md
+++ b/doc/functions/concat.md
@@ -1,0 +1,6 @@
+# concat
+
+Concatenates the provided arguments into a single string.
+
+## Arguments
+- `values...` – one or more values or JSONPath references.

--- a/doc/functions/count.md
+++ b/doc/functions/count.md
@@ -1,0 +1,6 @@
+# count
+
+Counts the number of items in the provided arguments.
+
+## Arguments
+- one or more values, arrays or objects.

--- a/doc/functions/datetime.md
+++ b/doc/functions/datetime.md
@@ -1,0 +1,7 @@
+# datetime
+
+Returns the current time. Optional parameters allow selecting the base time and formatting.
+
+## Arguments
+- `time` – optional indicator like `UTC` or `startOfDay`.
+- `format` – optional output format string.

--- a/doc/functions/fetch.md
+++ b/doc/functions/fetch.md
@@ -1,0 +1,6 @@
+# fetch
+
+Loads external JSON from a URL.
+
+## Arguments
+- `url` – address of the resource to load.

--- a/doc/functions/filterBySchema.md
+++ b/doc/functions/filterBySchema.md
@@ -1,0 +1,6 @@
+# filterBySchema
+
+Filters a JSON structure so that only properties defined in a schema remain.
+
+## Arguments
+- a JSON schema or a path to a schema.

--- a/doc/functions/format.md
+++ b/doc/functions/format.md
@@ -1,0 +1,7 @@
+# format
+
+Applies a format string to a value.
+
+## Arguments
+- `value` – value to format.
+- `pattern` – formatting string.

--- a/doc/functions/newGuid.md
+++ b/doc/functions/newGuid.md
@@ -1,0 +1,6 @@
+# newGuid
+
+Generates a GUID value.
+
+## Arguments
+*(none)*

--- a/doc/functions/parse.md
+++ b/doc/functions/parse.md
@@ -1,0 +1,6 @@
+# parse
+
+Parses a string into JSON.
+
+## Arguments
+- `jsonpath?` – optional path to a string value to parse.

--- a/doc/functions/partial.md
+++ b/doc/functions/partial.md
@@ -1,0 +1,6 @@
+# partial
+
+Extracts part of a JSON structure.
+
+## Arguments
+- `jsonpath` – path indicating the content to extract.

--- a/doc/functions/promote.md
+++ b/doc/functions/promote.md
@@ -1,0 +1,6 @@
+# promote
+
+Moves a child element up one level in the hierarchy.
+
+## Arguments
+- `jsonpath` – path to the element to promote.

--- a/doc/functions/sum.md
+++ b/doc/functions/sum.md
@@ -1,0 +1,6 @@
+# sum
+
+Adds numeric arguments together and returns the result.
+
+## Arguments
+- one or more numeric values or arrays.

--- a/doc/functions/toString.md
+++ b/doc/functions/toString.md
@@ -1,0 +1,6 @@
+# toString
+
+Converts a value to its string representation.
+
+## Arguments
+- `jsonpath?` – optional path to the value to convert.


### PR DESCRIPTION
## Summary
- add documentation folder for each command
- add documentation folder for each function
- link the new docs from the docs overview files

## Testing
- `dotnet test JLio.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842fa07584c832b8b5d94416f6401e6