### PR TITLE
Add Calculate function to Math extensions

### DIFF
--- a/JLio.Extensions.Math/Builders/CalculateBuilders.cs
+++ b/JLio.Extensions.Math/Builders/CalculateBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class CalculateBuilders
+{
+    public static Calculate Calculate(string expression)
+    {
+        return new Calculate(expression);
+    }
+}

--- a/JLio.Extensions.Math/Calculate.cs
+++ b/JLio.Extensions.Math/Calculate.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Data;
+using System.Linq;
+using System.Text.RegularExpressions;
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Extensions.Math;
+
+public class Calculate : FunctionBase
+{
+    public Calculate()
+    {
+    }
+
+    public Calculate(string expression)
+    {
+        Arguments.Add(new FunctionSupportedValue(new FixedValue(expression)));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        if (Arguments.Count != 1)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"failed: {FunctionName} requires 1 argument (expression)");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var argument = GetArguments(Arguments, currentToken, dataContext, context).FirstOrDefault();
+        if (argument == null || argument.Type != JTokenType.String)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"failed: {FunctionName} requires a string argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var expression = argument.Value<string>();
+
+        try
+        {
+            expression = ReplaceTokens(expression, currentToken, dataContext, context);
+        }
+        catch
+        {
+            context.LogError(CoreConstants.FunctionExecution, $"{FunctionName} transformation failed");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        try
+        {
+            var table = new DataTable();
+            var computeResult = table.Compute(expression, null);
+            var value = Convert.ToDouble(computeResult);
+            return new JLioFunctionResult(true, new JValue(value));
+        }
+        catch
+        {
+            context.LogError(CoreConstants.FunctionExecution, $"{FunctionName} transformation failed");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+    }
+
+    private string ReplaceTokens(string expression, JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var pattern = @"\[(.*?)\]";
+        var matches = Regex.Matches(expression, pattern);
+        foreach (Match match in matches.Cast<Match>().Reverse())
+        {
+            var inner = match.Groups[1].Value.Trim();
+            var valueProvider = FixedValue.DefaultFunctionConverter.ParseString(inner);
+            var result = valueProvider.GetValue(currentToken, dataContext, context);
+            if (!result.Success || result.Data.Count != 1)
+                throw new Exception("invalid token count");
+
+            var token = result.Data.First();
+            if (token.Type == JTokenType.Integer || token.Type == JTokenType.Float)
+            {
+                expression = expression.Remove(match.Index, match.Length)
+                    .Insert(match.Index, token.Value<double>().ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            else if (token.Type == JTokenType.String &&
+                     double.TryParse(token.Value<string>(), out var numeric))
+            {
+                expression = expression.Remove(match.Index, match.Length)
+                    .Insert(match.Index, numeric.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                throw new Exception("non numeric");
+            }
+        }
+
+        return expression;
+    }
+}
+

--- a/JLio.Extensions.Math/Calculate.cs
+++ b/JLio.Extensions.Math/Calculate.cs
@@ -41,7 +41,7 @@ public class Calculate : FunctionBase
 
         try
         {
-            expression = ReplaceTokens(expression, currentToken, dataContext, context);
+            expression = ReplaceTokens(expression, currentToken, dataContext, context).Trim('\'');
         }
         catch
         {
@@ -65,7 +65,7 @@ public class Calculate : FunctionBase
 
     private string ReplaceTokens(string expression, JToken currentToken, JToken dataContext, IExecutionContext context)
     {
-        var pattern = @"\[(.*?)\]";
+        var pattern = @"\{\{(.*?)\}\}";
         var matches = Regex.Matches(expression, pattern);
         foreach (Match match in matches.Cast<Match>().Reverse())
         {
@@ -82,7 +82,7 @@ public class Calculate : FunctionBase
                     .Insert(match.Index, token.Value<double>().ToString(System.Globalization.CultureInfo.InvariantCulture));
             }
             else if (token.Type == JTokenType.String &&
-                     double.TryParse(token.Value<string>(), out var numeric))
+                    double.TryParse(token.Value<string>(), out var numeric))
             {
                 expression = expression.Remove(match.Index, match.Length)
                     .Insert(match.Index, numeric.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -95,5 +95,6 @@ public class Calculate : FunctionBase
 
         return expression;
     }
+
 }
 

--- a/JLio.Extensions.Math/RegisterMathPack.cs
+++ b/JLio.Extensions.Math/RegisterMathPack.cs
@@ -14,6 +14,7 @@ namespace JLio.Extensions.Math
             parseOptions.RegisterFunction<Sum>();
             parseOptions.RegisterFunction<Avg>();
             parseOptions.RegisterFunction<Count>();
+            parseOptions.RegisterFunction<Calculate>();
             return parseOptions;
         }
     }

--- a/JLio.UnitTests/FunctionsTests/CalculateTests.cs
+++ b/JLio.UnitTests/FunctionsTests/CalculateTests.cs
@@ -1,0 +1,58 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class CalculateTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=calculate('2+3')", "{}", 5)]
+    [TestCase("=calculate('2+[$.v]')", "{\"v\":3}", 5)]
+    public void calculateTests(string function, string data, double resultValue)
+    {
+        var script = $"[{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void calculateFailsOnMultiToken()
+    {
+        var script = "[{'path':'$.result','value':'=calculate(\'1+[ $.arr[*] ]\')','command':'add'}]".Replace("'","\"");
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{\"arr\":[1,2]}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+
+    [Test]
+    public void CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(CalculateBuilders.Calculate("1+[$.v]"))
+                .OnPath("$.result");
+        var token = JToken.Parse("{\"v\":2}");
+        var result = script.Execute(token);
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(3, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/CalculateTests.cs
+++ b/JLio.UnitTests/FunctionsTests/CalculateTests.cs
@@ -24,7 +24,7 @@ public class CalculateTests
     }
 
     [TestCase("=calculate('2+3')", "{}", 5)]
-    [TestCase("=calculate('2+[$.v]')", "{\"v\":3}", 5)]
+    [TestCase("=calculate('2+{{$.v}}')", "{\"v\":3}", 5)]
     public void calculateTests(string function, string data, double resultValue)
     {
         var script = $"[{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}]";
@@ -37,7 +37,13 @@ public class CalculateTests
     [Test]
     public void calculateFailsOnMultiToken()
     {
-        var script = "[{'path':'$.result','value':'=calculate(\'1+[ $.arr[*] ]\')','command':'add'}]".Replace("'","\"");
+        var script = @"[
+        {
+            ""path"": ""$.result"",
+            ""value"": ""=calculate('1+{{ $.arr[*] }}')"",
+            ""command"": ""add""
+        }
+    ]";
         var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{\"arr\":[1,2]}"), executionContext);
         Assert.IsFalse(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
@@ -47,7 +53,7 @@ public class CalculateTests
     public void CanBeUsedInFluentApi()
     {
         var script = new JLioScript()
-                .Add(CalculateBuilders.Calculate("1+[$.v]"))
+                .Add(CalculateBuilders.Calculate("1+{{$.v}}"))
                 .OnPath("$.result");
         var token = JToken.Parse("{\"v\":2}");
         var result = script.Execute(token);

--- a/doc/functions.md
+++ b/doc/functions.md
@@ -41,3 +41,4 @@ Example usage inside a command:
 - [count](functions/count.md)
 - [sum](functions/sum.md)
 - [filterBySchema](functions/filterBySchema.md)
+- [calculate](functions/calculate.md)

--- a/doc/functions/calculate.md
+++ b/doc/functions/calculate.md
@@ -1,0 +1,31 @@
+# Calculate Function Documentation
+
+## Overview
+
+The `Calculate` function evaluates a mathematical expression and returns the numeric result. Parts of the expression can reference other values or functions by placing them inside square brackets (`[]`). Each referenced value must resolve to a single token.
+
+## Syntax
+
+### Function Expression Format
+```json
+"=calculate('2 + [$.a] * 3')"
+```
+
+### Programmatic Usage
+```csharp
+var calc = new Calculate("1 + [$.value]");
+```
+
+## Parameters
+
+- **Expression**: A string containing the mathematical expression.
+- **Placeholders**: References to other values or functions enclosed in `[]`.
+
+## Example
+```json
+{
+  "path": "$.result",
+  "value": "=calculate('2 + [$.number]')",
+  "command": "add"
+}
+```


### PR DESCRIPTION
## Summary
- add Calculate function for evaluating expressions
- register Calculate in math pack
- add Calculate builders and unit tests
- document Calculate function

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68447d19910c832b9cc7a2acbf674d85