### PR TITLE
Add boolean condition support for IfElse

### DIFF
--- a/JLio.Commands/IfElse.cs
+++ b/JLio.Commands/IfElse.cs
@@ -15,6 +15,9 @@ public class IfElse : CommandBase
     [JsonProperty("second")]
     public IFunctionSupportedValue Second { get; set; }
 
+    [JsonProperty("condition")]
+    public IFunctionSupportedValue Condition { get; set; }
+
     [JsonProperty("ifScript")]
     public JLioScript IfScript { get; set; }
 
@@ -28,6 +31,21 @@ public class IfElse : CommandBase
         {
             validation.ValidationMessages.ForEach(m => context.LogWarning(CoreConstants.CommandExecution, m));
             return new JLioExecutionResult(false, dataContext);
+        }
+        if (Condition != null)
+        {
+            var conditionValue = Condition.GetValue(dataContext, dataContext, context).Data.GetJTokenValue();
+            if (conditionValue.Type != JTokenType.Boolean)
+            {
+                context.LogWarning(CoreConstants.CommandExecution,
+                    $"Condition for {CommandName} should evaluate to boolean");
+                return new JLioExecutionResult(false, dataContext);
+            }
+
+            if (conditionValue.Value<bool>())
+                return IfScript?.Execute(dataContext, context) ?? JLioExecutionResult.SuccessFul(dataContext);
+
+            return ElseScript?.Execute(dataContext, context) ?? JLioExecutionResult.SuccessFul(dataContext);
         }
 
         var firstValue = First.GetValue(dataContext, dataContext, context).Data.GetJTokenValue();
@@ -44,10 +62,13 @@ public class IfElse : CommandBase
     public override ValidationResult ValidateCommandInstance()
     {
         var result = new ValidationResult();
-        if (First == null)
-            result.ValidationMessages.Add($"First property for {CommandName} command is missing");
-        if (Second == null)
-            result.ValidationMessages.Add($"Second property for {CommandName} command is missing");
+        if (Condition == null)
+        {
+            if (First == null)
+                result.ValidationMessages.Add($"First property for {CommandName} command is missing");
+            if (Second == null)
+                result.ValidationMessages.Add($"Second property for {CommandName} command is missing");
+        }
         if (IfScript == null)
             result.ValidationMessages.Add($"IfScript property for {CommandName} command is missing");
         return result;

--- a/JLio.UnitTests/CommandsTests/IfElseTests.cs
+++ b/JLio.UnitTests/CommandsTests/IfElseTests.cs
@@ -92,4 +92,58 @@ public class IfElseTests
         Assert.IsTrue(result.Success);
         Assert.AreEqual("if", data.SelectToken("$.result")?.ToString());
     }
+
+    [Test]
+    public void ExecutesWithConditionArgumentTrue()
+    {
+        var data = JObject.Parse("{\"value\": true, \"result\": 0}");
+        var ifScript = new JLioScript()
+            .Set(new JValue(1))
+            .OnPath("$.result");
+        var elseScript = new JLioScript()
+            .Set(new JValue(-1))
+            .OnPath("$.result");
+
+        var command = new IfElse
+        {
+            Condition = Val(new JValue("$.value")),
+            IfScript = ifScript,
+            ElseScript = elseScript
+        };
+
+        var script = new JLioScript();
+        script.AddLine(command);
+
+        var result = script.Execute(data, executeOptions);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, data.SelectToken("$.result")?.Value<int>());
+    }
+
+    [Test]
+    public void ExecutesWithConditionArgumentFalse()
+    {
+        var data = JObject.Parse("{\"value\": false, \"result\": 0}");
+        var ifScript = new JLioScript()
+            .Set(new JValue(1))
+            .OnPath("$.result");
+        var elseScript = new JLioScript()
+            .Set(new JValue(-1))
+            .OnPath("$.result");
+
+        var command = new IfElse
+        {
+            Condition = Val(new JValue("$.value")),
+            IfScript = ifScript,
+            ElseScript = elseScript
+        };
+
+        var script = new JLioScript();
+        script.AddLine(command);
+
+        var result = script.Execute(data, executeOptions);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(-1, data.SelectToken("$.result")?.Value<int>());
+    }
 }

--- a/doc/commands/ifElse.md
+++ b/doc/commands/ifElse.md
@@ -1,8 +1,10 @@
 # IfElse Command Documentation
 
 ## Overview
-
-The `IfElse` command provides conditional execution logic by comparing two values and executing different script branches based on the comparison result. When the values are equal, the "if" script executes; otherwise, the "else" script executes. This enables dynamic, data-driven transformation workflows.
+The `IfElse` command provides conditional execution logic. It operates in two modes:
+1. **Comparison Mode** – compare two values (`first` and `second`). If they are equal the `ifScript` executes, otherwise the `elseScript` runs.
+2. **Condition Mode** – evaluate a boolean expression (`condition`). If it resolves to `true` the `ifScript` executes; otherwise the `elseScript` runs.
+This flexibility enables dynamic, data-driven transformation workflows.
 
 ## Syntax
 
@@ -29,11 +31,26 @@ The `IfElse` command provides conditional execution logic by comparing two value
 }
 ```
 
+```json
+{
+  "condition": "$.flag",
+  "ifScript": [
+    { "path": "$.result", "value": "true path", "command": "add" }
+  ],
+  "elseScript": [
+    { "path": "$.result", "value": "false path", "command": "add" }
+  ],
+  "command": "ifElse"
+}
+```
+
 ### Required Properties
-- **first**: First value for comparison (can be literal value, JSONPath, or function expression)
-- **second**: Second value for comparison (can be literal value, JSONPath, or function expression)
-- **ifScript**: Script to execute when first equals second
+- **ifScript**: Script to execute when the condition is met
 - **command**: Must be "ifElse"
+
+You must provide either:
+- **first** and **second**: values to compare (literal value, JSONPath, or function expression)
+- **condition**: a boolean expression resolving to `true` or `false`.
 
 ### Optional Properties
 - **elseScript**: Script to execute when first does not equal second (optional)


### PR DESCRIPTION
## Summary
- extend `IfElse` command with optional `condition` argument
- allow executing based on boolean condition in addition to comparing two values
- test new condition mode
- document condition mode usage in `ifElse` docs

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_b_68447d9fd60c832bb91ff9e1f558ea09