### PR TITLE
Implement Subtract math function

### DIFF
--- a/JLio.Extensions.Math/Builders/SubtractBuilders.cs
+++ b/JLio.Extensions.Math/Builders/SubtractBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class SubtractBuilders
+{
+    public static Subtract Subtract(params string[] arguments)
+    {
+        return new Subtract(arguments);
+    }
+}

--- a/JLio.Extensions.Math/RegisterMathPack.cs
+++ b/JLio.Extensions.Math/RegisterMathPack.cs
@@ -15,6 +15,7 @@ namespace JLio.Extensions.Math
             parseOptions.RegisterFunction<Avg>();
             parseOptions.RegisterFunction<Count>();
             parseOptions.RegisterFunction<Calculate>();
+            parseOptions.RegisterFunction<Subtract>();
             return parseOptions;
         }
     }

--- a/JLio.Extensions.Math/Subtract.cs
+++ b/JLio.Extensions.Math/Subtract.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Extensions.Math;
+
+public class Subtract : FunctionBase
+{
+    public Subtract()
+    {
+    }
+
+    public Subtract(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count != 2)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"failed: {FunctionName} requires 2 arguments (base, subtract)");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        double baseValue = 0;
+        if (!TryAddTokenValue(values[0], ref baseValue, context))
+        {
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        double subtractValue = 0;
+        if (!TryAddTokenValue(values[1], ref subtractValue, context))
+        {
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var result = baseValue - subtractValue;
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+
+    private bool TryAddTokenValue(JToken token, ref double result, IExecutionContext context)
+    {
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                result += token.Value<double>();
+                return true;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), out var numeric):
+                result += numeric;
+                return true;
+
+            case JTokenType.Null:
+                return true;
+
+            case JTokenType.Array:
+                return TryAddArrayValues((JArray)token, ref result, context);
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values or arrays. Current type = {token.Type}");
+                return false;
+        }
+    }
+
+    private bool TryAddArrayValues(JArray array, ref double result, IExecutionContext context)
+    {
+        foreach (var item in array)
+        {
+            if (!TryAddTokenValue(item, ref result, context))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/SubtractTests.cs
+++ b/JLio.UnitTests/FunctionsTests/SubtractTests.cs
@@ -1,0 +1,77 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class SubtractTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=subtract(10,3)", "{}", 7)]
+    [TestCase("=subtract('10','3')", "{}", 7)]
+    [TestCase("=subtract($.a,$.b)", "{\"a\":5,\"b\":2}", 3)]
+    [TestCase("=subtract($.a,$.b)", "{\"a\":null,\"b\":2}", -2)]
+    [TestCase("=subtract($.values[*],$.subs[*])", "{\"values\":[5,3],\"subs\":[2,1]}", 5)]
+    [TestCase("=subtract($.numbers[*],2)", "{\"numbers\":[2,3,4]}", 7)]
+    [TestCase("=subtract($.nested,$.b[*])", "{\"nested\":[1,[2,3]],\"b\":[1]}", 5)]
+    [TestCase("=subtract($.sa,$.sb)", "{\"sa\":\"10\",\"sb\":\"8\"}", 2)]
+    public void subtractTests(string function, string data, double resultValue)
+    {
+        var script = $"[{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(SubtractBuilders.Subtract("5", "2"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(3, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void ScriptFailsOnInvalidValue()
+    {
+        var script = "[{'path':'$.result','value':'=subtract($.obj,$.a)','command':'add'}]".Replace("'","\"");
+        var data = "{\"obj\":{\"v\":1},\"a\":2}";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JToken.Parse(data), executionContext);
+
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+
+    [Test]
+    public void ScriptFailsOnWrongArgumentCount()
+    {
+        var script = "[{'path':'$.result','value':'=subtract($.a)','command':'add'}]".Replace("'","\"");
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JToken.Parse("{\"a\":1}"), executionContext);
+
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/SubtractTests.cs
+++ b/JLio.UnitTests/FunctionsTests/SubtractTests.cs
@@ -24,7 +24,7 @@ public class SubtractTests
     }
 
     [TestCase("=subtract(10,3)", "{}", 7)]
-    [TestCase("=subtract('10','3')", "{}", 7)]
+    [TestCase("=subtract(parse('10'),parse('3'))", "{}", 7)]
     [TestCase("=subtract($.a,$.b)", "{\"a\":5,\"b\":2}", 3)]
     [TestCase("=subtract($.a,$.b)", "{\"a\":null,\"b\":2}", -2)]
     [TestCase("=subtract($.values[*],$.subs[*])", "{\"values\":[5,3],\"subs\":[2,1]}", 5)]

--- a/doc/functions/subtract.md
+++ b/doc/functions/subtract.md
@@ -1,0 +1,108 @@
+# Subtract Function Documentation
+
+## Overview
+
+The `Subtract` function subtracts the second numeric argument from the first. Each argument may resolve to a single value or a collection of values. When a JSONPath expression or array returns multiple tokens, those tokens are summed before performing the subtraction. Null values are ignored and non‑numeric values cause the function to fail.
+
+## Installation
+
+### Extension Pack Registration
+```csharp
+// Register math functions extension pack
+var parseOptions = ParseOptions.CreateDefault().RegisterMath();
+
+// Use in script parsing
+var script = JLioConvert.Parse(scriptJson, parseOptions);
+```
+
+## Syntax
+
+### Function Expression Format
+```json
+"=subtract(base, value)"
+```
+
+Examples:
+```json
+"=subtract(10, 3)"                 // 7
+"=subtract($.a, $.b)"               // subtract tokens
+"=subtract($.values[*], 5)"         // first argument is array
+"=subtract($.a[*], $.b[*])"         // both arguments are arrays
+```
+
+### Programmatic Usage
+```csharp
+// With literal arguments
+var subtractFunction = new Subtract("10", "3");
+
+// Empty constructor for dynamic arguments
+var subtractFunction = new Subtract();
+```
+
+### Builder Pattern
+```csharp
+var subtractFunction = SubtractBuilders.Subtract("10", "3");
+var pathSubtract = SubtractBuilders.Subtract("$.a[*]", "$.b[*]");
+```
+
+## Parameters
+
+- **base**: first numeric value or collection
+- **value**: second numeric value or collection
+- **Argument Types**:
+  - Literal numbers or numeric strings
+  - JSONPath expressions
+  - Array references (including nested arrays)
+- **Return Type**: Double (JValue)
+
+## Examples
+
+### Basic Subtraction
+```json
+{
+  "path": "$.difference",
+  "value": "=subtract($.a, $.b)",
+  "command": "add"
+}
+```
+
+**Input Data**:
+```json
+{
+  "a": 10,
+  "b": 3
+}
+```
+
+**Result**:
+```json
+{
+  "a": 10,
+  "b": 3,
+  "difference": 7
+}
+```
+
+### Array Subtraction
+```json
+{
+  "path": "$.diff",
+  "value": "=subtract($.list[*], 2)",
+  "command": "add"
+}
+```
+
+**Input Data**:
+```json
+{
+  "list": [2, 3, 4]
+}
+```
+
+**Result**:
+```json
+{
+  "list": [2, 3, 4],
+  "diff": 7
+}
+```


### PR DESCRIPTION
## Summary
- add `Subtract` math function and builder
- register the function in `RegisterMathPack`
- document the subtract function
- add unit tests
- expand subtract tests and doc examples

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684930fa8c84832692fb31d6a813e113