### PR TITLE
Add Distinct command

### DIFF
--- a/JLio.Commands/Advanced/Builders/DistinctBuilders.cs
+++ b/JLio.Commands/Advanced/Builders/DistinctBuilders.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using JLio.Core.Models;
+
+namespace JLio.Commands.Advanced.Builders;
+
+public static class DistinctBuilders
+{
+    public static JLioScript Distinct(this JLioScript source, string path)
+    {
+        source.AddLine(new Distinct(path));
+        return source;
+    }
+
+    public static JLioScript Distinct(this JLioScript source, string path, List<string> keyPaths)
+    {
+        source.AddLine(new Distinct(path) { KeyPaths = keyPaths });
+        return source;
+    }
+}
+

--- a/JLio.Commands/Advanced/Distinct.cs
+++ b/JLio.Commands/Advanced/Distinct.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using JLio.Commands.Advanced.Settings;
+using JLio.Commands.Logic;
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Commands.Advanced;
+
+public class Distinct : CommandBase
+{
+    private IExecutionContext executionContext;
+
+    public Distinct()
+    {
+    }
+
+    public Distinct(string path)
+    {
+        Path = path;
+    }
+
+    [JsonProperty("path")]
+    public string Path { get; set; }
+
+    [JsonProperty("keyPaths")]
+    public List<string> KeyPaths { get; set; } = new List<string>();
+
+    public override JLioExecutionResult Execute(JToken dataContext, IExecutionContext context)
+    {
+        executionContext = context;
+        var validationResult = ValidateCommandInstance();
+        if (!validationResult.IsValid)
+        {
+            validationResult.ValidationMessages.ForEach(i =>
+                context.LogWarning(CoreConstants.CommandExecution, i));
+            return new JLioExecutionResult(false, dataContext);
+        }
+
+        var targets = context.ItemsFetcher.SelectTokens(Path, dataContext);
+        foreach (var target in targets)
+        {
+            if (target is not JArray array)
+            {
+                context.LogWarning(CoreConstants.CommandExecution,
+                    $"{CommandName}: {target.Path} is not an array");
+                continue;
+            }
+
+            var arraySettings = new MergeArraySettings
+            {
+                KeyPaths = KeyPaths,
+                UniqueItemsWithoutKeys = true
+            };
+
+            var resultArray = new JArray();
+            foreach (var child in array.Children())
+                AddToArray(resultArray, child.DeepClone(), arraySettings);
+
+            array.Replace(resultArray);
+        }
+
+        return new JLioExecutionResult(true, dataContext);
+    }
+
+    public override ValidationResult ValidateCommandInstance()
+    {
+        var result = new ValidationResult();
+        if (string.IsNullOrWhiteSpace(Path))
+            result.ValidationMessages.Add($"Path property for {CommandName} command is missing");
+        return result;
+    }
+
+    private void AddToArray(JArray target, JToken itemToAdd, MergeArraySettings arraySettings)
+    {
+        if (arraySettings.KeyPaths.Count > 0)
+            AdditemsWithKeyMatch(target, itemToAdd, arraySettings);
+        else if (!arraySettings.UniqueItemsWithoutKeys || !ArrayHelpers.IsItemInArray(target, itemToAdd))
+            target.Add(itemToAdd);
+    }
+
+    private void AdditemsWithKeyMatch(JArray target, JToken itemToAdd, MergeArraySettings arraySettings)
+    {
+        var targetItems = ArrayHelpers.FindTargetArrayElementForKeys(target, itemToAdd, arraySettings.KeyPaths);
+        if (!targetItems.Any())
+            target.Add(itemToAdd);
+        else
+            targetItems.ForEach(t => MergeTokens(itemToAdd, t, arraySettings));
+    }
+
+    private void MergeTokens(JToken source, JToken target, MergeArraySettings arraySettings)
+    {
+        var tmp = new JObject
+        {
+            ["source"] = source,
+            ["target"] = target
+        };
+
+        var settings = new MergeSettings
+        {
+            ArraySettings = new List<MergeArraySettings>
+            {
+                new MergeArraySettings
+                {
+                    ArrayPath = "$.target",
+                    KeyPaths = arraySettings.KeyPaths,
+                    UniqueItemsWithoutKeys = arraySettings.UniqueItemsWithoutKeys
+                }
+            }
+        };
+
+        var merge = new Merge("$.source", "$.target", settings);
+        merge.Execute(tmp, executionContext);
+    }
+}
+

--- a/JLio.UnitTests/CommandsTests/DistinctTests.cs
+++ b/JLio.UnitTests/CommandsTests/DistinctTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Linq;
+using JLio.Commands.Advanced;
+using JLio.Commands.Advanced.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JLio.UnitTests.CommandsTests;
+
+public class DistinctTests
+{
+    private IExecutionContext executeOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        executeOptions = ExecutionContext.CreateDefault();
+    }
+
+    [Test]
+    public void DistinctSimpleArray()
+    {
+        var data = JObject.Parse("{\"arr\": [1,2,3,4,2] }");
+        var result = new Distinct("$.arr").Execute(data, executeOptions);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(JToken.DeepEquals(JArray.Parse("[1,2,3,4]"), data.SelectToken("$.arr")));
+    }
+
+    [Test]
+    public void DistinctComplexArrayWithKeys()
+    {
+        var data = JObject.Parse("{\"arr\":[{\"id\":1,\"value\":\"a\"},{\"id\":2,\"value\":\"b\"},{\"id\":1,\"value\":\"c\"}]}");
+        var command = new Distinct("$.arr") { KeyPaths = new List<string> { "id" } };
+        command.Execute(data, executeOptions);
+
+        var expected = JArray.Parse("[{\"id\":1,\"value\":\"c\"},{\"id\":2,\"value\":\"b\"}]");
+        Assert.IsTrue(JToken.DeepEquals(expected, data.SelectToken("$.arr")));
+    }
+
+    [Test]
+    public void CanUseFluentApi()
+    {
+        var script = new JLioScript()
+            .Distinct("$.arr")
+            .Distinct("$.arr2", new List<string> { "id" });
+        var result = script.Execute(new JObject
+        {
+            ["arr"] = new JArray(1,2,2),
+            ["arr2"] = new JArray(new JObject { ["id"] = 1 }, new JObject { ["id"] = 1 })
+        });
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(2, result.Data["arr"].Count());
+        Assert.AreEqual(1, result.Data["arr2"].Count());
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Some commands allow their value parameters to be evaluated as JLio functions. Th
 | `remove`     | no |
 | `compare`    | no |
 | `merge`      | no |
+| `distinct`   | no |
 
 
 ### Add

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -26,6 +26,7 @@ The table below lists the available commands and their main arguments.
 | **ifElse** | `condition`, `then`, `else` | Execute nested scripts conditionally. |
 | **merge** | `path`, `value` | Merge objects and arrays. |
 | **compare** | `path`, `value` | Compare two values according to settings. |
+| **distinct** | `path` | Remove duplicate array items. |
 
 Arguments can reference JSONPath locations and may use functions in the `value` field.
 
@@ -41,3 +42,4 @@ Arguments can reference JSONPath locations and may use functions in the `value` 
 - [ifElse](commands/ifElse.md)
 - [merge](commands/merge.md)
 - [compare](commands/compare.md)
+- [distinct](commands/distinct.md)

--- a/doc/commands/distinct.md
+++ b/doc/commands/distinct.md
@@ -1,0 +1,43 @@
+# Distinct Command Documentation
+
+## Overview
+
+The `Distinct` command removes duplicate items from arrays. It leverages the merge logic so that when duplicate objects are found they are merged together. Primitive values are de-duplicated as well.
+
+## Syntax
+
+### JSON Script Format
+```json
+{
+  "path": "$.array.path",
+  "command": "distinct",
+  "keyPaths": ["id"]
+}
+```
+
+### Required Properties
+- **path**: JSONPath to the array(s) to process
+- **command**: Must be `distinct`
+
+### Optional Properties
+- **keyPaths**: List of property paths used to match objects
+
+## Programmatic Usage
+
+### Constructors
+```csharp
+var command = new Distinct("$.items");
+var commandWithKeys = new Distinct("$.items") { KeyPaths = new List<string>{"id"} };
+```
+
+### Fluent API
+```csharp
+var script = new JLioScript()
+    .Distinct("$.numbers")
+    .Distinct("$.objects", new List<string>{"id"});
+```
+
+## Behavior
+- Primitive arrays are reduced to unique values.
+- Arrays of objects use `keyPaths` to identify duplicates. Matching objects are merged using the `Merge` command logic.
+


### PR DESCRIPTION
## Summary
- add `Distinct` command with key-based merging
- support fluent API via `DistinctBuilders`
- document the new command
- list command in docs and README
- add unit tests for distinct arrays

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684960c9a8248326b8414014b321fd64