### PR TITLE
Enhance type safety and null handling across classes

### DIFF
--- a/JLio.Extensions.ETL/Commands/Models/ResolveKey.cs
+++ b/JLio.Extensions.ETL/Commands/Models/ResolveKey.cs
@@ -5,9 +5,9 @@ namespace JLio.Extensions.ETL.Commands.Models
     public class ResolveKey
     {
         [JsonProperty("keyPath")]
-        public string KeyPath { get; set; }
+        public required string KeyPath { get; set; }
 
         [JsonProperty("referenceKeyPath")]
-        public string ReferenceKeyPath { get; set; }
+        public required string ReferenceKeyPath { get; set; }
     }
 }

--- a/JLio.Extensions.ETL/Commands/Models/ResolveSetting.cs
+++ b/JLio.Extensions.ETL/Commands/Models/ResolveSetting.cs
@@ -6,12 +6,12 @@ namespace JLio.Extensions.ETL.Commands.Models
     public class ResolveSetting
     {
         [JsonProperty("resolveKeys")]
-        public List<ResolveKey> ResolveKeys { get; set; } = new List<ResolveKey>();
+        public List<ResolveKey> ResolveKeys { get; set; } = new ();
 
         [JsonProperty("referencesCollectionPath")]
-        public string ReferencesCollectionPath { get; set; }
+        public required string ReferencesCollectionPath { get; set; }
 
         [JsonProperty("values")]
-        public List<ResolveValue> Values { get; set; } = new List<ResolveValue>();
+        public List<ResolveValue> Values { get; set; } = new ();
     }
 }

--- a/JLio.Extensions.ETL/Commands/Models/ResolveValue.cs
+++ b/JLio.Extensions.ETL/Commands/Models/ResolveValue.cs
@@ -25,10 +25,10 @@ namespace JLio.Extensions.ETL.Commands.Models
     public class ResolveValue
     {
         [JsonProperty("targetPath")]
-        public string TargetPath { get; set; }
+        public required string TargetPath { get; set; }
 
         [JsonProperty("value")]
-        public IFunctionSupportedValue Value { get; set; }
+        public required IFunctionSupportedValue Value { get; set; }
 
         [JsonProperty("resolveTypeBehavior")]
         public ResolveTypeBehavior ResolveTypeBehavior { get; set; } = ResolveTypeBehavior.DependingOnResult;

--- a/JLio.Extensions.Text/Format.cs
+++ b/JLio.Extensions.Text/Format.cs
@@ -44,7 +44,7 @@ public class Format : FunctionBase
         if (value.Type == JTokenType.String)
         {
             DateTime datetimeValue; 
-            if(DateTime.TryParse(value.Value<string>().ToString(), CultureInfo.InvariantCulture, DateTimeStyles.None, out datetimeValue)){
+            if(DateTime.TryParse(value.Value<string>()?.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.None, out datetimeValue)){
                 return JLioFunctionResult.SuccessFul(new JValue(datetimeValue.ToString(formatString)));
             }
             return JLioFunctionResult.SuccessFul(value);

--- a/JLio.UnitTests/CommandsTests/ResolveTests.cs
+++ b/JLio.UnitTests/CommandsTests/ResolveTests.cs
@@ -337,7 +337,10 @@ namespace JLio.UnitTests.CommandsTests
         [Test]
         public void CanValidateCommandInstance()
         {
-            var resolveCommand = new Resolve();
+            var resolveCommand = new Resolve
+            {
+                Path = "" // Empty path to trigger validation error
+            };
 
             var validationResult = resolveCommand.ValidateCommandInstance();
 
@@ -356,7 +359,8 @@ namespace JLio.UnitTests.CommandsTests
                 {
                     new ResolveSetting
                     {
-                        // Missing ResolveKeys, ReferencesCollectionPath, and Values
+                        ReferencesCollectionPath = "" // Empty to trigger validation error
+                        // Missing ResolveKeys and Values to trigger those validation errors
                     }
                 }
             };

--- a/JLio.UnitTests/FunctionsTests/CalculateTests.cs
+++ b/JLio.UnitTests/FunctionsTests/CalculateTests.cs
@@ -37,7 +37,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>());
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>());
     }
     #endregion
 
@@ -56,7 +56,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>(), 0.0001);
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>(), 0.0001);
     }
     #endregion
 
@@ -75,7 +75,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>(), 0.000001);
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>(), 0.000001);
     }
     #endregion
 
@@ -93,7 +93,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>(), 0.000001);
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>(), 0.000001);
     }
     #endregion
 
@@ -109,7 +109,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>());
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>());
     }
     #endregion
 
@@ -126,7 +126,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>(), 0.01);
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>(), 0.01);
     }
     #endregion
 
@@ -142,7 +142,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>());
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>());
     }
     #endregion
 
@@ -166,7 +166,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>(), 0.01);
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>(), 0.01);
     }
     #endregion
 
@@ -184,7 +184,7 @@ public class CalculateExtendedTests
 
         Assert.IsTrue(result.Success);
         Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
-        Assert.AreEqual(expected, result.Data.SelectToken("$.result")?.Value<double>());
+        Assert.AreEqual(expected, result.Data.SelectToken("$.result").Value<double>());
     }
     #endregion
 
@@ -304,7 +304,7 @@ public class CalculateExtendedTests
         var result = script.Execute(token);
         Assert.IsNotNull(result);
         Assert.IsTrue(result.Success);
-        Assert.AreEqual(77.97, result.Data.SelectToken("$.total")?.Value<double>(), 0.01);
+        Assert.AreEqual(77.97, result.Data.SelectToken("$.total").Value<double>(), 0.01);
     }
     #endregion
 


### PR DESCRIPTION
Enhance type safety and null handling across classes

- Introduced `required` keyword for essential properties in `ResolveKey`, `ResolveSetting`, and `ResolveValue` classes.
- Simplified initialization of `ResolveKeys` and `Values` in `ResolveSetting` using C# 9.0 syntax.
- Made `executionContext` nullable in `Resolve` class and added null checks to prevent exceptions.
- Updated methods to return nullable types (`JToken?`) for better handling of unresolved values.
- Modified `Calculate` class methods to return nullable types and include null checks.
- Cleaned up `Assert.AreEqual` statements in `CalculateExtendedTests` by removing null-conditional operators.
- Overall improvements enhance code safety, readability, and maintainability.

#### PR Classification
Code cleanup and enhancement of null handling.

#### PR Summary
This pull request introduces the `required` keyword for certain properties, enhances null handling across multiple classes, and simplifies list initialization. 
- `ResolveKey`, `ResolveSetting`, and `ResolveValue`: Added `required` keyword to properties and simplified list initialization.
- `Resolve`: Made `executionContext` nullable and added null checks in various methods.
- `Calculate`: Improved null handling in `GetExpression` and `ProcessExpression` methods.
- `ReplaceToken`: Added checks for empty tokens to improve error handling.
- Unit tests in `ResolveTests.cs` and `CalculateTests.cs`: Updated to reflect changes in property initialization and null handling.
