### PR TITLE
Add new mathematical functions and improve parsing

### DIFF
--- a/JLio.Extensions.Math/Abs.cs
+++ b/JLio.Extensions.Math/Abs.cs
@@ -1,0 +1,58 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Abs : FunctionBase
+{
+    public Abs()
+    {
+    }
+
+    public Abs(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count != 1)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires exactly one argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var token = values[0];
+        double value;
+
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                value = token.Value<double>();
+                break;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                value = numeric;
+                break;
+
+            case JTokenType.Null:
+                value = 0;
+                break;
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values. Current type = {token.Type}");
+                return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var result = System.Math.Abs(value);
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+}

--- a/JLio.Extensions.Math/Avg.cs
+++ b/JLio.Extensions.Math/Avg.cs
@@ -2,6 +2,7 @@ using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using Newtonsoft.Json.Linq;
+using System.Globalization;
 
 namespace JLio.Extensions.Math;
 
@@ -45,7 +46,7 @@ public class Avg : FunctionBase
                 count++;
                 return true;
 
-            case JTokenType.String when double.TryParse(token.Value<string>(), out var numeric):
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
                 sum += numeric;
                 count++;
                 return true;

--- a/JLio.Extensions.Math/Builders/AbsBuilders.cs
+++ b/JLio.Extensions.Math/Builders/AbsBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class AbsBuilders
+{
+    public static Abs Abs(string argument)
+    {
+        return new Abs(argument);
+    }
+}

--- a/JLio.Extensions.Math/Builders/CeilBuilders.cs
+++ b/JLio.Extensions.Math/Builders/CeilBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class CeilBuilders
+{
+    public static Ceil Ceil(string argument)
+    {
+        return new Ceil(argument);
+    }
+}

--- a/JLio.Extensions.Math/Builders/CeilingBuilders.cs
+++ b/JLio.Extensions.Math/Builders/CeilingBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class CeilingBuilders
+{
+    public static Ceiling Ceiling(string argument)
+    {
+        return new Ceiling(argument);
+    }
+}

--- a/JLio.Extensions.Math/Builders/FloorBuilders.cs
+++ b/JLio.Extensions.Math/Builders/FloorBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class FloorBuilders
+{
+    public static Floor Floor(string argument)
+    {
+        return new Floor(argument);
+    }
+}

--- a/JLio.Extensions.Math/Builders/MaxBuilders.cs
+++ b/JLio.Extensions.Math/Builders/MaxBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class MaxBuilders
+{
+    public static Max Max(params string[] arguments)
+    {
+        return new Max(arguments);
+    }
+}

--- a/JLio.Extensions.Math/Builders/MedianBuilders.cs
+++ b/JLio.Extensions.Math/Builders/MedianBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class MedianBuilders
+{
+    public static Median Median(params string[] arguments)
+    {
+        return new Median(arguments);
+    }
+}

--- a/JLio.Extensions.Math/Builders/MinBuilders.cs
+++ b/JLio.Extensions.Math/Builders/MinBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class MinBuilders
+{
+    public static Min Min(params string[] arguments)
+    {
+        return new Min(arguments);
+    }
+}

--- a/JLio.Extensions.Math/Builders/PowBuilders.cs
+++ b/JLio.Extensions.Math/Builders/PowBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class PowBuilders
+{
+    public static Pow Pow(string baseValue, string exponent)
+    {
+        return new Pow(baseValue, exponent);
+    }
+}

--- a/JLio.Extensions.Math/Builders/RoundBuilders.cs
+++ b/JLio.Extensions.Math/Builders/RoundBuilders.cs
@@ -1,0 +1,14 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class RoundBuilders
+{
+    public static Round Round(string value)
+    {
+        return new Round(value);
+    }
+
+    public static Round Round(string value, string decimals)
+    {
+        return new Round(value, decimals);
+    }
+}

--- a/JLio.Extensions.Math/Builders/SqrtBuilders.cs
+++ b/JLio.Extensions.Math/Builders/SqrtBuilders.cs
@@ -1,0 +1,9 @@
+namespace JLio.Extensions.Math.Builders;
+
+public static class SqrtBuilders
+{
+    public static Sqrt Sqrt(string argument)
+    {
+        return new Sqrt(argument);
+    }
+}

--- a/JLio.Extensions.Math/Ceil.cs
+++ b/JLio.Extensions.Math/Ceil.cs
@@ -1,0 +1,36 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace JLio.Extensions.Math;
+
+/// <summary>
+/// Alias for Ceiling function - rounds up to nearest integer
+/// </summary>
+public class Ceil : FunctionBase
+{
+    public Ceil()
+    {
+    }
+
+    public Ceil(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        // Delegate to Ceiling function by creating a new instance with the same arguments
+        var ceiling = new Ceiling();
+
+        // Copy arguments from this function to the ceiling function
+        foreach (var argument in Arguments)
+        {
+            ceiling.Arguments.Add(argument);
+        }
+
+        return ceiling.Execute(currentToken, dataContext, context);
+    }
+}

--- a/JLio.Extensions.Math/Ceiling.cs
+++ b/JLio.Extensions.Math/Ceiling.cs
@@ -1,0 +1,58 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Ceiling : FunctionBase
+{
+    public Ceiling()
+    {
+    }
+
+    public Ceiling(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count != 1)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires exactly one argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var token = values[0];
+        double value;
+
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                value = token.Value<double>();
+                break;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                value = numeric;
+                break;
+
+            case JTokenType.Null:
+                value = 0;
+                break;
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values. Current type = {token.Type}");
+                return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var result = System.Math.Ceiling(value);
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+}

--- a/JLio.Extensions.Math/Floor.cs
+++ b/JLio.Extensions.Math/Floor.cs
@@ -1,0 +1,58 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Floor : FunctionBase
+{
+    public Floor()
+    {
+    }
+
+    public Floor(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count != 1)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires exactly one argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var token = values[0];
+        double value;
+
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                value = token.Value<double>();
+                break;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                value = numeric;
+                break;
+
+            case JTokenType.Null:
+                value = 0;
+                break;
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values. Current type = {token.Type}");
+                return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var result = System.Math.Floor(value);
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+}

--- a/JLio.Extensions.Math/Max.cs
+++ b/JLio.Extensions.Math/Max.cs
@@ -1,0 +1,98 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Max : FunctionBase
+{
+    public Max()
+    {
+    }
+
+    public Max(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count == 0)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires at least one argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        double maxValue = double.MinValue;
+        bool hasValue = false;
+
+        foreach (var token in values)
+        {
+            if (!TryFindMaxValue(token, ref maxValue, ref hasValue, context))
+            {
+                return JLioFunctionResult.Failed(currentToken);
+            }
+        }
+
+        if (!hasValue)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} found no valid numeric values");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        return new JLioFunctionResult(true, new JValue(maxValue));
+    }
+
+    private bool TryFindMaxValue(JToken token, ref double maxValue, ref bool hasValue, IExecutionContext context)
+    {
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                var value = token.Value<double>();
+                if (!hasValue || value > maxValue)
+                {
+                    maxValue = value;
+                }
+                hasValue = true;
+                return true;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                if (!hasValue || numeric > maxValue)
+                {
+                    maxValue = numeric;
+                }
+                hasValue = true;
+                return true;
+
+            case JTokenType.Null:
+                return true;
+
+            case JTokenType.Array:
+                return TryFindMaxInArray((JArray)token, ref maxValue, ref hasValue, context);
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values or arrays. Current type = {token.Type}");
+                return false;
+        }
+    }
+
+    private bool TryFindMaxInArray(JArray array, ref double maxValue, ref bool hasValue, IExecutionContext context)
+    {
+        foreach (var item in array)
+        {
+            if (!TryFindMaxValue(item, ref maxValue, ref hasValue, context))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/JLio.Extensions.Math/Median.cs
+++ b/JLio.Extensions.Math/Median.cs
@@ -1,0 +1,105 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Median : FunctionBase
+{
+    public Median()
+    {
+    }
+
+    public Median(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count == 0)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires at least one argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var numbers = new List<double>();
+
+        foreach (var token in values)
+        {
+            if (!TryCollectNumbers(token, numbers, context))
+            {
+                return JLioFunctionResult.Failed(currentToken);
+            }
+        }
+
+        if (numbers.Count == 0)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} found no valid numeric values");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        // Sort the numbers to find median
+        numbers.Sort();
+
+        double median;
+        int count = numbers.Count;
+        
+        if (count % 2 == 0)
+        {
+            // Even number of elements - average of middle two
+            median = (numbers[count / 2 - 1] + numbers[count / 2]) / 2.0;
+        }
+        else
+        {
+            // Odd number of elements - middle element
+            median = numbers[count / 2];
+        }
+
+        return new JLioFunctionResult(true, new JValue(median));
+    }
+
+    private bool TryCollectNumbers(JToken token, List<double> numbers, IExecutionContext context)
+    {
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                numbers.Add(token.Value<double>());
+                return true;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                numbers.Add(numeric);
+                return true;
+
+            case JTokenType.Null:
+                return true;
+
+            case JTokenType.Array:
+                return TryCollectNumbersFromArray((JArray)token, numbers, context);
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values or arrays. Current type = {token.Type}");
+                return false;
+        }
+    }
+
+    private bool TryCollectNumbersFromArray(JArray array, List<double> numbers, IExecutionContext context)
+    {
+        foreach (var item in array)
+        {
+            if (!TryCollectNumbers(item, numbers, context))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/JLio.Extensions.Math/Min.cs
+++ b/JLio.Extensions.Math/Min.cs
@@ -1,0 +1,98 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Min : FunctionBase
+{
+    public Min()
+    {
+    }
+
+    public Min(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count == 0)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires at least one argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        double minValue = double.MaxValue;
+        bool hasValue = false;
+
+        foreach (var token in values)
+        {
+            if (!TryFindMinValue(token, ref minValue, ref hasValue, context))
+            {
+                return JLioFunctionResult.Failed(currentToken);
+            }
+        }
+
+        if (!hasValue)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} found no valid numeric values");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        return new JLioFunctionResult(true, new JValue(minValue));
+    }
+
+    private bool TryFindMinValue(JToken token, ref double minValue, ref bool hasValue, IExecutionContext context)
+    {
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                var value = token.Value<double>();
+                if (!hasValue || value < minValue)
+                {
+                    minValue = value;
+                }
+                hasValue = true;
+                return true;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                if (!hasValue || numeric < minValue)
+                {
+                    minValue = numeric;
+                }
+                hasValue = true;
+                return true;
+
+            case JTokenType.Null:
+                return true;
+
+            case JTokenType.Array:
+                return TryFindMinInArray((JArray)token, ref minValue, ref hasValue, context);
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values or arrays. Current type = {token.Type}");
+                return false;
+        }
+    }
+
+    private bool TryFindMinInArray(JArray array, ref double minValue, ref bool hasValue, IExecutionContext context)
+    {
+        foreach (var item in array)
+        {
+            if (!TryFindMinValue(item, ref minValue, ref hasValue, context))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/JLio.Extensions.Math/Pow.cs
+++ b/JLio.Extensions.Math/Pow.cs
@@ -1,0 +1,91 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Pow : FunctionBase
+{
+    public Pow()
+    {
+    }
+
+    public Pow(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count != 2)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires exactly 2 arguments (base, exponent)");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        // Get base value
+        double baseValue;
+        var baseToken = values[0];
+        switch (baseToken.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                baseValue = baseToken.Value<double>();
+                break;
+
+            case JTokenType.String when double.TryParse(baseToken.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                baseValue = numeric;
+                break;
+
+            case JTokenType.Null:
+                baseValue = 0;
+                break;
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} base argument must be numeric. Current type = {baseToken.Type}");
+                return JLioFunctionResult.Failed(currentToken);
+        }
+
+        // Get exponent value
+        double exponent;
+        var exponentToken = values[1];
+        switch (exponentToken.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                exponent = exponentToken.Value<double>();
+                break;
+
+            case JTokenType.String when double.TryParse(exponentToken.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                exponent = numeric;
+                break;
+
+            case JTokenType.Null:
+                exponent = 0;
+                break;
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} exponent argument must be numeric. Current type = {exponentToken.Type}");
+                return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var result = System.Math.Pow(baseValue, exponent);
+
+        // Check for invalid results
+        if (double.IsNaN(result) || double.IsInfinity(result))
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} calculation resulted in an invalid number (base={baseValue}, exponent={exponent})");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+}

--- a/JLio.Extensions.Math/RegisterMathPack.cs
+++ b/JLio.Extensions.Math/RegisterMathPack.cs
@@ -11,6 +11,16 @@ public static class RegisterMathPack
         parseOptions.RegisterFunction<Count>();
         parseOptions.RegisterFunction<Calculate>();
         parseOptions.RegisterFunction<Subtract>();
+        parseOptions.RegisterFunction<Min>();
+        parseOptions.RegisterFunction<Max>();
+        parseOptions.RegisterFunction<Abs>();
+        parseOptions.RegisterFunction<Round>();
+        parseOptions.RegisterFunction<Floor>();
+        parseOptions.RegisterFunction<Ceiling>();
+        parseOptions.RegisterFunction<Ceil>(); // Alias for Ceiling
+        parseOptions.RegisterFunction<Pow>();
+        parseOptions.RegisterFunction<Sqrt>();
+        parseOptions.RegisterFunction<Median>();
         return parseOptions;
     }
 }

--- a/JLio.Extensions.Math/Round.cs
+++ b/JLio.Extensions.Math/Round.cs
@@ -1,0 +1,91 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Round : FunctionBase
+{
+    public Round()
+    {
+    }
+
+    public Round(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count < 1 || values.Count > 2)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires 1 or 2 arguments (value, [decimals])");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        // Get the value to round
+        double value;
+        var valueToken = values[0];
+        switch (valueToken.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                value = valueToken.Value<double>();
+                break;
+
+            case JTokenType.String when double.TryParse(valueToken.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                value = numeric;
+                break;
+
+            case JTokenType.Null:
+                value = 0;
+                break;
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} first argument must be numeric. Current type = {valueToken.Type}");
+                return JLioFunctionResult.Failed(currentToken);
+        }
+
+        // Get decimal places (default to 0)
+        int decimals = 0;
+        if (values.Count == 2)
+        {
+            var decimalsToken = values[1];
+            switch (decimalsToken.Type)
+            {
+                case JTokenType.Integer:
+                    decimals = decimalsToken.Value<int>();
+                    break;
+
+                case JTokenType.String when int.TryParse(decimalsToken.Value<string>(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var intVal):
+                    decimals = intVal;
+                    break;
+
+                case JTokenType.Null:
+                    decimals = 0;
+                    break;
+
+                default:
+                    context.LogError(CoreConstants.FunctionExecution,
+                        $"{FunctionName} second argument (decimals) must be an integer. Current type = {decimalsToken.Type}");
+                    return JLioFunctionResult.Failed(currentToken);
+            }
+        }
+
+        if (decimals < 0 || decimals > 15)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} decimal places must be between 0 and 15. Current value = {decimals}");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var result = System.Math.Round(value, decimals);
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+}

--- a/JLio.Extensions.Math/Sqrt.cs
+++ b/JLio.Extensions.Math/Sqrt.cs
@@ -1,0 +1,65 @@
+using JLio.Core;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+
+namespace JLio.Extensions.Math;
+
+public class Sqrt : FunctionBase
+{
+    public Sqrt()
+    {
+    }
+
+    public Sqrt(params string[] arguments)
+    {
+        arguments.ToList().ForEach(a =>
+            Arguments.Add(new FunctionSupportedValue(new FixedValue(a))));
+    }
+
+    public override JLioFunctionResult Execute(JToken currentToken, JToken dataContext, IExecutionContext context)
+    {
+        var values = GetArguments(Arguments, currentToken, dataContext, context);
+        if (values.Count != 1)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} requires exactly one argument");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var token = values[0];
+        double value;
+
+        switch (token.Type)
+        {
+            case JTokenType.Integer:
+            case JTokenType.Float:
+                value = token.Value<double>();
+                break;
+
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
+                value = numeric;
+                break;
+
+            case JTokenType.Null:
+                value = 0;
+                break;
+
+            default:
+                context.LogError(CoreConstants.FunctionExecution,
+                    $"{FunctionName} can only handle numeric values. Current type = {token.Type}");
+                return JLioFunctionResult.Failed(currentToken);
+        }
+
+        if (value < 0)
+        {
+            context.LogError(CoreConstants.FunctionExecution,
+                $"{FunctionName} cannot calculate square root of negative number: {value}");
+            return JLioFunctionResult.Failed(currentToken);
+        }
+
+        var result = System.Math.Sqrt(value);
+        return new JLioFunctionResult(true, new JValue(result));
+    }
+}

--- a/JLio.Extensions.Math/Sum.cs
+++ b/JLio.Extensions.Math/Sum.cs
@@ -2,6 +2,7 @@ using JLio.Core;
 using JLio.Core.Contracts;
 using JLio.Core.Models;
 using Newtonsoft.Json.Linq;
+using System.Globalization;
 
 namespace JLio.Extensions.Math;
 
@@ -42,7 +43,7 @@ public class Sum : FunctionBase
                 result += token.Value<double>();
                 return true;
 
-            case JTokenType.String when double.TryParse(token.Value<string>(), out var numeric):
+            case JTokenType.String when double.TryParse(token.Value<string>(), NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric):
                 result += numeric;
                 return true;
 

--- a/JLio.UnitTests/FunctionsTests/AbsTests.cs
+++ b/JLio.UnitTests/FunctionsTests/AbsTests.cs
@@ -1,0 +1,65 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class AbsTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=abs(5)", "{}", 5)]
+    [TestCase("=abs(-5)", "{}", 5)]
+    [TestCase("=abs(0)", "{}", 0)]
+    [TestCase("=abs(-3.14)", "{}", 3.14)]
+    [TestCase("=abs($.value)", "{\"value\":-42}", 42)]
+    [TestCase("=abs($.value)", "{\"value\":42}", 42)]
+    public void AbsTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Abs_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(AbsBuilders.Abs("-10"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(10, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Abs_FailsWithMultipleArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=abs(1,2)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/CeilingTests.cs
+++ b/JLio.UnitTests/FunctionsTests/CeilingTests.cs
@@ -1,0 +1,67 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class CeilingTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=ceiling(3.14)", "{}", 4)]
+    [TestCase("=ceiling(3.01)", "{}", 4)]
+    [TestCase("=ceiling(-2.3)", "{}", -2)]
+    [TestCase("=ceiling(-2.9)", "{}", -2)]
+    [TestCase("=ceiling(5)", "{}", 5)]
+    [TestCase("=ceiling(0)", "{}", 0)]
+    [TestCase("=ceiling($.value)", "{\"value\":3.25}", 4)]
+    [TestCase("=ceiling($.value)", "{\"value\":-1.75}", -1)]
+    public void CeilingTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Ceiling_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(CeilingBuilders.Ceiling("3.01"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(4, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Ceiling_FailsWithMultipleArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=ceiling(1,2)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/FloorTests.cs
+++ b/JLio.UnitTests/FunctionsTests/FloorTests.cs
@@ -1,0 +1,67 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class FloorTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=floor(3.14)", "{}", 3)]
+    [TestCase("=floor(3.99)", "{}", 3)]
+    [TestCase("=floor(-2.3)", "{}", -3)]
+    [TestCase("=floor(-2.9)", "{}", -3)]
+    [TestCase("=floor(5)", "{}", 5)]
+    [TestCase("=floor(0)", "{}", 0)]
+    [TestCase("=floor($.value)", "{\"value\":3.75}", 3)]
+    [TestCase("=floor($.value)", "{\"value\":-1.25}", -2)]
+    public void FloorTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Floor_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(FloorBuilders.Floor("3.99"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(3, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Floor_FailsWithMultipleArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=floor(1,2)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/MaxTests.cs
+++ b/JLio.UnitTests/FunctionsTests/MaxTests.cs
@@ -1,0 +1,65 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class MaxTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=max(1,2,3)", "{}", 3)]
+    [TestCase("=max(5,2,8)", "{}", 8)]
+    [TestCase("=max(-1,-2,-3)", "{}", -1)]
+    [TestCase("=max($.a,$.b,$.c)", "{\"a\":5,\"b\":2,\"c\":8}", 8)]
+    [TestCase("=max($.numbers[*])", "{\"numbers\":[4,6,1,9]}", 9)]
+    [TestCase("=max($.value)", "{\"value\":42}", 42)]
+    public void MaxTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Max_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(MaxBuilders.Max("1", "5", "3"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(5, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Max_FailsWithNoArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=max()\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/MedianTests.cs
+++ b/JLio.UnitTests/FunctionsTests/MedianTests.cs
@@ -1,0 +1,91 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class MedianTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=median(1,2,3)", "{}", 2)]
+    [TestCase("=median(1,2,3,4)", "{}", 2.5)]
+    [TestCase("=median(5,1,3,2,4)", "{}", 3)]
+    [TestCase("=median(-1,0,1)", "{}", 0)]
+    [TestCase("=median($.numbers[*])", "{\"numbers\":[7,2,5,1,3]}", 3)]
+    [TestCase("=median($.numbers[*])", "{\"numbers\":[4,2,6,8]}", 5)]
+    [TestCase("=median($.value)", "{\"value\":42}", 42)]
+    [TestCase("=median($.a,$.b,$.c)", "{\"a\":10,\"b\":5,\"c\":15}", 10)]
+    public void MedianTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Median_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(MedianBuilders.Median("1", "3", "5", "7", "9"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(5, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Median_HandlesEvenNumberOfElements()
+    {
+        var script = new JLioScript()
+                .Add(MedianBuilders.Median("2", "4", "6", "8"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(5, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Median_WorksWithComplexArrays()
+    {
+        var data = "{\"students\":[{\"grade\":85},{\"grade\":92},{\"grade\":78},{\"grade\":95},{\"grade\":88}]}";
+        var script = "[{\"path\":\"$.medianGrade\",\"value\":\"=median($.students[*].grade)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JToken.Parse(data), executionContext);
+        
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(88, result.Data.SelectToken("$.medianGrade")?.Value<double>());
+    }
+
+    [Test]
+    public void Median_FailsWithNoArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=median()\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/MinTests.cs
+++ b/JLio.UnitTests/FunctionsTests/MinTests.cs
@@ -1,0 +1,65 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class MinTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=min(1,2,3)", "{}", 1)]
+    [TestCase("=min(5,2,8)", "{}", 2)]
+    [TestCase("=min(-1,2,3)", "{}", -1)]
+    [TestCase("=min($.a,$.b,$.c)", "{\"a\":5,\"b\":2,\"c\":8}", 2)]
+    [TestCase("=min($.numbers[*])", "{\"numbers\":[4,6,1,9]}", 1)]
+    [TestCase("=min($.value)", "{\"value\":42}", 42)]
+    public void MinTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.AreEqual(resultValue, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Min_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(MinBuilders.Min("1", "5", "3"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Min_FailsWithNoArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=min()\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/PowTests.cs
+++ b/JLio.UnitTests/FunctionsTests/PowTests.cs
@@ -1,0 +1,77 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class PowTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=pow(2, 3)", "{}", 8)]
+    [TestCase("=pow(5, 2)", "{}", 25)]
+    [TestCase("=pow(2, 0)", "{}", 1)]
+    [TestCase("=pow(0, 5)", "{}", 0)]
+    [TestCase("=pow(4, 0.5)", "{}", 2)]
+    [TestCase("=pow(-2, 3)", "{}", -8)]
+    [TestCase("=pow(-2, 2)", "{}", 4)]
+    [TestCase("=pow($.base, $.exp)", "{\"base\":3,\"exp\":4}", 81)]
+    [TestCase("=pow(10, -2)", "{}", 0.01)]
+    public void PowTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.That(result.Data.SelectToken("$.result")?.Value<double>(), Is.EqualTo(resultValue).Within(0.0001));
+    }
+
+    [Test]
+    public void Pow_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(PowBuilders.Pow("2", "8"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(256, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Pow_FailsWithOneArgument()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=pow(2)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+
+    [Test]
+    public void Pow_FailsWithThreeArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=pow(2,3,4)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/RoundTests.cs
+++ b/JLio.UnitTests/FunctionsTests/RoundTests.cs
@@ -1,0 +1,90 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class RoundTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=round(3.14)", "{}", 3)]
+    [TestCase("=round(3.75)", "{}", 4)]
+    [TestCase("=round(-2.3)", "{}", -2)]
+    [TestCase("=round(-2.7)", "{}", -3)]
+    [TestCase("=round(3.14159, 2)", "{}", 3.14)]
+    [TestCase("=round(3.14159, 3)", "{}", 3.142)]
+    [TestCase("=round(1234.5678, 1)", "{}", 1234.6)]
+    [TestCase("=round($.value, 2)", "{\"value\":3.14159}", 3.14)]
+    [TestCase("=round($.value, $.decimals)", "{\"value\":3.14159,\"decimals\":3}", 3.142)]
+    public void RoundTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.That(result.Data.SelectToken("$.result")?.Value<double>(), Is.EqualTo(resultValue).Within(0.0001));
+    }
+
+    [Test]
+    public void Round_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(RoundBuilders.Round("3.14159", "2"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.That(result.Data.SelectToken("$.result")?.Value<double>(), Is.EqualTo(3.14).Within(0.001));
+    }
+
+    [Test]
+    public void Round_CanBeUsedWithSingleArgument()
+    {
+        var script = new JLioScript()
+                .Add(RoundBuilders.Round("3.75"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(4, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Round_FailsWithTooManyArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=round(1,2,3)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+
+    [Test]
+    public void Round_FailsWithInvalidDecimals()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=round(3.14, -1)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}

--- a/JLio.UnitTests/FunctionsTests/SqrtTests.cs
+++ b/JLio.UnitTests/FunctionsTests/SqrtTests.cs
@@ -1,0 +1,76 @@
+using JLio.Client;
+using JLio.Commands.Builders;
+using JLio.Core.Contracts;
+using JLio.Core.Models;
+using JLio.Extensions.Math;
+using JLio.Extensions.Math.Builders;
+using JLio.Extensions.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Linq;
+
+namespace JLio.UnitTests.FunctionsTests;
+
+public class SqrtTests
+{
+    private IExecutionContext executionContext;
+    private IParseOptions parseOptions;
+
+    [SetUp]
+    public void Setup()
+    {
+        parseOptions = ParseOptions.CreateDefault().RegisterMath().RegisterText();
+        executionContext = ExecutionContext.CreateDefault();
+    }
+
+    [TestCase("=sqrt(4)", "{}", 2)]
+    [TestCase("=sqrt(9)", "{}", 3)]
+    [TestCase("=sqrt(16)", "{}", 4)]
+    [TestCase("=sqrt(0)", "{}", 0)]
+    [TestCase("=sqrt(1)", "{}", 1)]
+    [TestCase("=sqrt(2)", "{}", 1.4142)]
+    [TestCase("=sqrt($.value)", "{\"value\":25}", 5)]
+    [TestCase("=sqrt($.value)", "{\"value\":6.25}", 2.5)]
+    public void SqrtTests_ValidInputs(string function, string data, double resultValue)
+    {
+        var script = $"{{\"path\":\"$.result\",\"value\":\"{function}\",\"command\":\"add\"}}";
+        var scriptArray = $"[{script}]";
+        var result = JLioConvert.Parse(scriptArray, parseOptions).Execute(JToken.Parse(data), executionContext);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().TrueForAll(i => i.Level != LogLevel.Error));
+        Assert.IsNotNull(result.Data.SelectToken("$.result"));
+        Assert.That(result.Data.SelectToken("$.result")?.Value<double>(), Is.EqualTo(resultValue).Within(0.0001));
+    }
+
+    [Test]
+    public void Sqrt_CanBeUsedInFluentApi()
+    {
+        var script = new JLioScript()
+                .Add(SqrtBuilders.Sqrt("64"))
+                .OnPath("$.result");
+        var result = script.Execute(new JObject());
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(8, result.Data.SelectToken("$.result")?.Value<double>());
+    }
+
+    [Test]
+    public void Sqrt_FailsWithNegativeNumber()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=sqrt(-4)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+
+    [Test]
+    public void Sqrt_FailsWithMultipleArguments()
+    {
+        var script = "[{\"path\":\"$.result\",\"value\":\"=sqrt(4,9)\",\"command\":\"add\"}]";
+        var result = JLioConvert.Parse(script, parseOptions).Execute(JObject.Parse("{}"), executionContext);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(executionContext.GetLogEntries().Any(i => i.Level == LogLevel.Error));
+    }
+}


### PR DESCRIPTION
Add new mathematical functions and improve parsing

This commit introduces several new mathematical functions to the JLio.Extensions.Math namespace, including `Abs`, `Ceil`, `Ceiling`, `Floor`, `Max`, `Median`, `Min`, `Pow`, `Round`, and `Sqrt`. Each function is implemented as a class inheriting from `FunctionBase`, with accompanying builders for easier instantiation.

Additionally, the `Avg` and `Sum` classes have been updated to better handle string inputs as doubles using `NumberStyles.Float` and `CultureInfo.InvariantCulture`.

New test classes have been added for each function, ensuring comprehensive testing across various scenarios. The `RegisterMathPack` class has also been updated to include the new functions, enhancing the overall mathematical capabilities of the JLio framework.